### PR TITLE
feat: GitHub OAuth 認証フロー実装 (Port + Adapter)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+VITE_GITHUB_CLIENT_ID=your_github_client_id
+VITE_GITHUB_CLIENT_SECRET=your_github_client_secret

--- a/src/adapter/chrome/identity.adapter.ts
+++ b/src/adapter/chrome/identity.adapter.ts
@@ -1,0 +1,175 @@
+import type { AuthPort } from "../../domain/ports/auth.port";
+import type { StoragePort } from "../../domain/ports/storage.port";
+import { generateCodeChallenge, generateCodeVerifier, generateState } from "../../shared/crypto";
+import type { AuthToken, OAuthConfig } from "../../shared/types/auth";
+import { AuthError } from "../../shared/types/auth";
+
+const TOKEN_STORAGE_KEY = "github_auth_token";
+
+export class ChromeIdentityAdapter implements AuthPort {
+	private pendingAuth: Promise<AuthToken> | null = null;
+
+	constructor(
+		private readonly storage: StoragePort,
+		private readonly config: OAuthConfig,
+	) {}
+
+	authorize(): Promise<AuthToken> {
+		if (this.pendingAuth) {
+			return this.pendingAuth;
+		}
+		this.pendingAuth = this.executeAuthFlow().finally(() => {
+			this.pendingAuth = null;
+		});
+		return this.pendingAuth;
+	}
+
+	async getToken(): Promise<AuthToken | null> {
+		return this.storage.get<AuthToken>(TOKEN_STORAGE_KEY);
+	}
+
+	async clearToken(): Promise<void> {
+		await this.storage.remove(TOKEN_STORAGE_KEY);
+	}
+
+	async isAuthenticated(): Promise<boolean> {
+		const token = await this.getToken();
+		return token !== null;
+	}
+
+	private async executeAuthFlow(): Promise<AuthToken> {
+		const state = generateState();
+		const codeVerifier = generateCodeVerifier();
+		const codeChallenge = await generateCodeChallenge(codeVerifier);
+
+		const redirectUrl = await this.launchAuthFlow(state, codeChallenge);
+		const { code, returnedState } = this.parseRedirectUrl(redirectUrl);
+
+		this.verifyState(state, returnedState);
+
+		const token = await this.exchangeCodeForToken(code, codeVerifier);
+		await this.storage.set(TOKEN_STORAGE_KEY, token);
+		return token;
+	}
+
+	private async launchAuthFlow(state: string, codeChallenge: string): Promise<string> {
+		const authUrl = this.buildAuthorizationUrl(state, codeChallenge);
+
+		let responseUrl: string | undefined;
+		try {
+			responseUrl = await chrome.identity.launchWebAuthFlow({
+				url: authUrl,
+				interactive: true,
+			});
+		} catch (error: unknown) {
+			const message = error instanceof Error ? error.message : "Unknown error";
+			throw new AuthError("user_cancelled", "User cancelled the authentication flow", {
+				cause: new Error(message),
+			});
+		}
+
+		if (!responseUrl) {
+			throw new AuthError("user_cancelled", "Authentication flow returned no response");
+		}
+
+		return responseUrl;
+	}
+
+	private buildAuthorizationUrl(state: string, codeChallenge: string): string {
+		const params = new URLSearchParams({
+			client_id: this.config.clientId,
+			redirect_uri: this.config.redirectUri,
+			scope: this.config.scopes.join(" "),
+			state,
+			code_challenge: codeChallenge,
+			code_challenge_method: "S256",
+		});
+		return `${this.config.authorizationEndpoint}?${params.toString()}`;
+	}
+
+	private parseRedirectUrl(redirectUrl: string): {
+		code: string;
+		returnedState: string;
+	} {
+		const url = new URL(redirectUrl);
+		const code = url.searchParams.get("code");
+		const returnedState = url.searchParams.get("state");
+
+		if (!code || !returnedState) {
+			throw new AuthError("authorization_failed", "Missing code or state in redirect URL");
+		}
+
+		return { code, returnedState };
+	}
+
+	private verifyState(expected: string, actual: string): void {
+		if (expected !== actual) {
+			throw new AuthError("csrf_mismatch", "State parameter mismatch: possible CSRF attack");
+		}
+	}
+
+	private async exchangeCodeForToken(code: string, codeVerifier: string): Promise<AuthToken> {
+		const body = new URLSearchParams({
+			client_id: this.config.clientId,
+			client_secret: this.config.clientSecret,
+			code,
+			redirect_uri: this.config.redirectUri,
+			code_verifier: codeVerifier,
+		});
+
+		let response: Response;
+		try {
+			response = await fetch(this.config.tokenEndpoint, {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/x-www-form-urlencoded",
+					Accept: "application/json",
+				},
+				body: body.toString(),
+			});
+		} catch (error: unknown) {
+			const message = error instanceof Error ? error.message : "Unknown error";
+			throw new AuthError("token_exchange_failed", `Token exchange failed: ${message}`);
+		}
+
+		if (!response.ok) {
+			throw new AuthError(
+				"token_exchange_failed",
+				`Token exchange failed: ${response.status} ${response.statusText}`,
+			);
+		}
+
+		const data = await this.parseResponseBody(response);
+		return this.validateTokenData(data);
+	}
+
+	private async parseResponseBody(response: Response): Promise<Record<string, unknown>> {
+		try {
+			return (await response.json()) as Record<string, unknown>;
+		} catch (error: unknown) {
+			const message = error instanceof Error ? error.message : "Unknown error";
+			throw new AuthError(
+				"token_exchange_failed",
+				`Token exchange failed: invalid response body: ${message}`,
+			);
+		}
+	}
+
+	private validateTokenData(data: Record<string, unknown>): AuthToken {
+		if (typeof data.error === "string") {
+			const description =
+				typeof data.error_description === "string" ? data.error_description : data.error;
+			throw new AuthError("token_exchange_failed", `Token exchange failed: ${description}`);
+		}
+
+		if (typeof data.access_token !== "string" || !data.access_token) {
+			throw new AuthError("token_exchange_failed", "Invalid token response: missing access_token");
+		}
+
+		return {
+			accessToken: data.access_token,
+			tokenType: typeof data.token_type === "string" ? data.token_type : "bearer",
+			scope: typeof data.scope === "string" ? data.scope : "",
+		};
+	}
+}

--- a/src/adapter/chrome/storage.adapter.ts
+++ b/src/adapter/chrome/storage.adapter.ts
@@ -1,0 +1,19 @@
+import type { StoragePort } from "../../domain/ports/storage.port";
+
+export class ChromeStorageAdapter implements StoragePort {
+	async get<T>(key: string): Promise<T | null> {
+		const result = await chrome.storage.local.get(key);
+		if (key in result) {
+			return result[key] as T;
+		}
+		return null;
+	}
+
+	async set<T>(key: string, value: T): Promise<void> {
+		await chrome.storage.local.set({ [key]: value });
+	}
+
+	async remove(key: string): Promise<void> {
+		await chrome.storage.local.remove(key);
+	}
+}

--- a/src/background/bootstrap.ts
+++ b/src/background/bootstrap.ts
@@ -1,7 +1,18 @@
+import { ChromeIdentityAdapter } from "../adapter/chrome/identity.adapter";
+import { ChromeStorageAdapter } from "../adapter/chrome/storage.adapter";
+import type { AuthPort } from "../domain/ports/auth.port";
+import { createOAuthConfig } from "../shared/config/oauth.config";
+
+type AppServices = {
+	readonly auth: AuthPort;
+};
+
 /**
- * Composition Root: アプリケーション初期化
- * 将来ここで Adapter を Port に注入する
+ * Composition Root: Adapter を Port に注入してアプリケーションを構成する
  */
-export function initializeApp(): void {
-	// Adapter 注入はここに追加していく
+export function initializeApp(): AppServices {
+	const config = createOAuthConfig(chrome.identity.getRedirectURL());
+	const storage = new ChromeStorageAdapter();
+	const auth = new ChromeIdentityAdapter(storage, config);
+	return { auth };
 }

--- a/src/domain/ports/auth.port.ts
+++ b/src/domain/ports/auth.port.ts
@@ -1,0 +1,8 @@
+import type { AuthToken } from "../../shared/types/auth";
+
+export interface AuthPort {
+	authorize(): Promise<AuthToken>;
+	getToken(): Promise<AuthToken | null>;
+	clearToken(): Promise<void>;
+	isAuthenticated(): Promise<boolean>;
+}

--- a/src/domain/ports/storage.port.ts
+++ b/src/domain/ports/storage.port.ts
@@ -1,0 +1,5 @@
+export interface StoragePort {
+	get<T>(key: string): Promise<T | null>;
+	set<T>(key: string, value: T): Promise<void>;
+	remove(key: string): Promise<void>;
+}

--- a/src/shared/config/oauth.config.ts
+++ b/src/shared/config/oauth.config.ts
@@ -1,0 +1,24 @@
+import type { OAuthConfig } from "../types/auth";
+
+export function createOAuthConfig(redirectUri: string): OAuthConfig {
+	const clientId = import.meta.env.VITE_GITHUB_CLIENT_ID;
+	const clientSecret = import.meta.env.VITE_GITHUB_CLIENT_SECRET;
+
+	if (!clientId) {
+		throw new Error("VITE_GITHUB_CLIENT_ID is not configured");
+	}
+	if (!clientSecret) {
+		throw new Error("VITE_GITHUB_CLIENT_SECRET is not configured");
+	}
+
+	return {
+		clientId,
+		clientSecret,
+		authorizationEndpoint: "https://github.com/login/oauth/authorize",
+		tokenEndpoint: "https://github.com/login/oauth/access_token",
+		redirectUri,
+		// GitHub API で private repo の PR を読むには "repo" スコープが必須
+		// (read-only の個別スコープは GitHub が提供していない)
+		scopes: ["repo"],
+	};
+}

--- a/src/shared/crypto.ts
+++ b/src/shared/crypto.ts
@@ -1,0 +1,47 @@
+/**
+ * OAuth PKCE / CSRF 用の暗号ユーティリティ
+ */
+
+function toBase64Url(buffer: ArrayBuffer): string {
+	const bytes = new Uint8Array(buffer);
+	let binary = "";
+	for (const byte of bytes) {
+		binary += String.fromCharCode(byte);
+	}
+	return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, "");
+}
+
+/** CSRF 対策用のランダム state 文字列を生成 */
+export function generateState(): string {
+	const bytes = new Uint8Array(32);
+	crypto.getRandomValues(bytes);
+	return toBase64Url(bytes.buffer);
+}
+
+/** PKCE code_verifier を生成 (RFC 7636 準拠の unreserved characters) */
+export function generateCodeVerifier(): string {
+	const unreserved = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~";
+	// rejection sampling で modulo bias を排除
+	// Math.floor(256 / 66) * 66 = 198
+	const maxUnbiased = Math.floor(256 / unreserved.length) * unreserved.length;
+	const result: string[] = [];
+	while (result.length < 64) {
+		const bytes = new Uint8Array(128);
+		crypto.getRandomValues(bytes);
+		for (const byte of bytes) {
+			if (result.length >= 64) break;
+			if (byte < maxUnbiased) {
+				result.push(unreserved[byte % unreserved.length]);
+			}
+		}
+	}
+	return result.join("");
+}
+
+/** PKCE code_challenge を生成 (S256) */
+export async function generateCodeChallenge(verifier: string): Promise<string> {
+	const encoder = new TextEncoder();
+	const data = encoder.encode(verifier);
+	const digest = await crypto.subtle.digest("SHA-256", data);
+	return toBase64Url(digest);
+}

--- a/src/shared/types/auth.ts
+++ b/src/shared/types/auth.ts
@@ -1,0 +1,29 @@
+export type OAuthConfig = {
+	readonly clientId: string;
+	readonly clientSecret: string;
+	readonly authorizationEndpoint: string;
+	readonly tokenEndpoint: string;
+	readonly redirectUri: string;
+	readonly scopes: readonly string[];
+};
+
+export type AuthToken = {
+	readonly accessToken: string;
+	readonly tokenType: string;
+	readonly scope: string;
+};
+
+export type AuthErrorCode =
+	| "authorization_failed"
+	| "token_exchange_failed"
+	| "csrf_mismatch"
+	| "user_cancelled";
+
+export class AuthError extends Error {
+	readonly code: AuthErrorCode;
+	constructor(code: AuthErrorCode, message: string, options?: ErrorOptions) {
+		super(message, options);
+		this.name = "AuthError";
+		this.code = code;
+	}
+}

--- a/src/test/adapter/chrome/identity.adapter.test.ts
+++ b/src/test/adapter/chrome/identity.adapter.test.ts
@@ -1,0 +1,396 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ChromeIdentityAdapter } from "../../../adapter/chrome/identity.adapter";
+import type { StoragePort } from "../../../domain/ports/storage.port";
+import type { AuthToken, OAuthConfig } from "../../../shared/types/auth";
+import { AuthError } from "../../../shared/types/auth";
+import { getChromeMock, resetChromeMock, setupChromeMock } from "../../mocks/chrome.mock";
+
+function createMockStorage(): StoragePort & {
+	get: ReturnType<typeof vi.fn>;
+	set: ReturnType<typeof vi.fn>;
+	remove: ReturnType<typeof vi.fn>;
+} {
+	return {
+		get: vi.fn(),
+		set: vi.fn(),
+		remove: vi.fn(),
+	};
+}
+
+const TEST_CONFIG: OAuthConfig = {
+	clientId: "test-client-id",
+	clientSecret: "test-client-secret",
+	authorizationEndpoint: "https://github.com/login/oauth/authorize",
+	tokenEndpoint: "https://github.com/login/oauth/access_token",
+	redirectUri: "https://mock-redirect.chromiumapp.org/",
+	scopes: ["repo"],
+};
+
+const MOCK_TOKEN: AuthToken = {
+	accessToken: "gho_test_access_token",
+	tokenType: "bearer",
+	scope: "repo",
+};
+
+describe("ChromeIdentityAdapter", () => {
+	let adapter: ChromeIdentityAdapter;
+	let mockStorage: ReturnType<typeof createMockStorage>;
+	let originalFetch: typeof globalThis.fetch;
+
+	beforeEach(() => {
+		setupChromeMock();
+		mockStorage = createMockStorage();
+		mockStorage.set.mockResolvedValue(undefined);
+		mockStorage.remove.mockResolvedValue(undefined);
+		adapter = new ChromeIdentityAdapter(mockStorage, TEST_CONFIG);
+		originalFetch = globalThis.fetch;
+	});
+
+	afterEach(() => {
+		resetChromeMock();
+		globalThis.fetch = originalFetch;
+	});
+
+	describe("authorize", () => {
+		function setupSuccessfulFlow(): void {
+			const chromeMock = getChromeMock();
+			chromeMock.identity.launchWebAuthFlow.mockImplementation(async (details: { url: string }) => {
+				const url = new URL(details.url);
+				const state = url.searchParams.get("state");
+				return `${TEST_CONFIG.redirectUri}?code=test-auth-code&state=${state}`;
+			});
+
+			globalThis.fetch = vi.fn().mockResolvedValue({
+				ok: true,
+				json: async () => ({
+					access_token: MOCK_TOKEN.accessToken,
+					token_type: MOCK_TOKEN.tokenType,
+					scope: MOCK_TOKEN.scope,
+				}),
+			});
+		}
+
+		it("should call chrome.identity.launchWebAuthFlow with interactive: true", async () => {
+			setupSuccessfulFlow();
+			const chromeMock = getChromeMock();
+
+			await adapter.authorize();
+
+			expect(chromeMock.identity.launchWebAuthFlow).toHaveBeenCalledWith(
+				expect.objectContaining({ interactive: true }),
+			);
+		});
+
+		it("should extract authorization code from redirect URL", async () => {
+			setupSuccessfulFlow();
+
+			await adapter.authorize();
+
+			const fetchMock = globalThis.fetch as ReturnType<typeof vi.fn>;
+			expect(fetchMock).toHaveBeenCalled();
+			const [, options] = fetchMock.mock.calls[0] as [string, RequestInit];
+			const body = options.body as string;
+			expect(body).toContain("code=test-auth-code");
+		});
+
+		it("should throw AuthError with csrf_mismatch when state does not match", async () => {
+			const chromeMock = getChromeMock();
+			chromeMock.identity.launchWebAuthFlow.mockResolvedValue(
+				`${TEST_CONFIG.redirectUri}?code=test-code&state=wrong-state`,
+			);
+
+			const error = await adapter.authorize().catch((e: unknown) => e);
+			expect(error).toBeInstanceOf(AuthError);
+			expect((error as AuthError).code).toBe("csrf_mismatch");
+		});
+
+		it("should POST to token endpoint for token exchange", async () => {
+			setupSuccessfulFlow();
+
+			await adapter.authorize();
+
+			const fetchMock = globalThis.fetch as ReturnType<typeof vi.fn>;
+			expect(fetchMock).toHaveBeenCalledWith(
+				TEST_CONFIG.tokenEndpoint,
+				expect.objectContaining({ method: "POST" }),
+			);
+		});
+
+		it("should include client_secret in POST body, not URL params", async () => {
+			setupSuccessfulFlow();
+
+			await adapter.authorize();
+
+			const fetchMock = globalThis.fetch as ReturnType<typeof vi.fn>;
+			const [url, options] = fetchMock.mock.calls[0] as [string, RequestInit];
+			expect(url).not.toContain("client_secret");
+			const body = options.body as string;
+			expect(body).toContain("client_secret=test-client-secret");
+		});
+
+		it("should save the token via StoragePort", async () => {
+			setupSuccessfulFlow();
+
+			await adapter.authorize();
+
+			expect(mockStorage.set).toHaveBeenCalledWith("github_auth_token", MOCK_TOKEN);
+		});
+
+		it("should throw AuthError with token_exchange_failed when token endpoint returns HTTP error", async () => {
+			const chromeMock = getChromeMock();
+			chromeMock.identity.launchWebAuthFlow.mockImplementation(async (details: { url: string }) => {
+				const url = new URL(details.url);
+				const state = url.searchParams.get("state");
+				return `${TEST_CONFIG.redirectUri}?code=test-code&state=${state}`;
+			});
+
+			globalThis.fetch = vi.fn().mockResolvedValue({
+				ok: false,
+				status: 401,
+				statusText: "Unauthorized",
+			});
+
+			const error = await adapter.authorize().catch((e: unknown) => e);
+			expect(error).toBeInstanceOf(AuthError);
+			expect((error as AuthError).code).toBe("token_exchange_failed");
+		});
+
+		it("should throw AuthError when GitHub returns 200 with error body", async () => {
+			const chromeMock = getChromeMock();
+			chromeMock.identity.launchWebAuthFlow.mockImplementation(async (details: { url: string }) => {
+				const url = new URL(details.url);
+				const state = url.searchParams.get("state");
+				return `${TEST_CONFIG.redirectUri}?code=test-code&state=${state}`;
+			});
+
+			globalThis.fetch = vi.fn().mockResolvedValue({
+				ok: true,
+				json: async () => ({
+					error: "bad_verification_code",
+					error_description: "The code passed is incorrect or expired.",
+				}),
+			});
+
+			const error = await adapter.authorize().catch((e: unknown) => e);
+			expect(error).toBeInstanceOf(AuthError);
+			expect((error as AuthError).code).toBe("token_exchange_failed");
+			expect((error as AuthError).message).toContain("The code passed is incorrect or expired.");
+		});
+
+		it("should throw AuthError when access_token is missing from response", async () => {
+			const chromeMock = getChromeMock();
+			chromeMock.identity.launchWebAuthFlow.mockImplementation(async (details: { url: string }) => {
+				const url = new URL(details.url);
+				const state = url.searchParams.get("state");
+				return `${TEST_CONFIG.redirectUri}?code=test-code&state=${state}`;
+			});
+
+			globalThis.fetch = vi.fn().mockResolvedValue({
+				ok: true,
+				json: async () => ({
+					token_type: "bearer",
+					scope: "repo",
+				}),
+			});
+
+			const error = await adapter.authorize().catch((e: unknown) => e);
+			expect(error).toBeInstanceOf(AuthError);
+			expect((error as AuthError).code).toBe("token_exchange_failed");
+			expect((error as AuthError).message).toContain("missing access_token");
+		});
+
+		it("should throw AuthError when fetch rejects with network error", async () => {
+			const chromeMock = getChromeMock();
+			chromeMock.identity.launchWebAuthFlow.mockImplementation(async (details: { url: string }) => {
+				const url = new URL(details.url);
+				const state = url.searchParams.get("state");
+				return `${TEST_CONFIG.redirectUri}?code=test-code&state=${state}`;
+			});
+
+			globalThis.fetch = vi.fn().mockRejectedValue(new TypeError("Failed to fetch"));
+
+			const error = await adapter.authorize().catch((e: unknown) => e);
+			expect(error).toBeInstanceOf(AuthError);
+			expect((error as AuthError).code).toBe("token_exchange_failed");
+			expect((error as AuthError).message).toContain("Failed to fetch");
+		});
+
+		it("should throw AuthError with user_cancelled when launchWebAuthFlow returns undefined", async () => {
+			const chromeMock = getChromeMock();
+			chromeMock.identity.launchWebAuthFlow.mockResolvedValue(undefined);
+
+			const error = await adapter.authorize().catch((e: unknown) => e);
+			expect(error).toBeInstanceOf(AuthError);
+			expect((error as AuthError).code).toBe("user_cancelled");
+		});
+
+		it("should throw AuthError with user_cancelled when launchWebAuthFlow throws", async () => {
+			const chromeMock = getChromeMock();
+			chromeMock.identity.launchWebAuthFlow.mockRejectedValue(
+				new Error("The user did not approve access."),
+			);
+
+			const error = await adapter.authorize().catch((e: unknown) => e);
+			expect(error).toBeInstanceOf(AuthError);
+			expect((error as AuthError).code).toBe("user_cancelled");
+		});
+
+		it("should sanitize error cause to message-only when launchWebAuthFlow throws", async () => {
+			const chromeMock = getChromeMock();
+			const originalError = new Error("The user did not approve access.");
+			chromeMock.identity.launchWebAuthFlow.mockRejectedValue(originalError);
+
+			const error = await adapter.authorize().catch((e: unknown) => e);
+			expect(error).toBeInstanceOf(AuthError);
+			const cause = (error as AuthError).cause;
+			expect(cause).toBeInstanceOf(Error);
+			// cause は元のエラーオブジェクトではなく、message のみ引き継いだ新しい Error
+			expect(cause).not.toBe(originalError);
+			expect((cause as Error).message).toBe("The user did not approve access.");
+		});
+
+		it("should return the same promise for concurrent authorize calls", async () => {
+			setupSuccessfulFlow();
+
+			const promise1 = adapter.authorize();
+			const promise2 = adapter.authorize();
+
+			// 同じ Promise が返される
+			expect(promise2).toBe(promise1);
+
+			const [result1, result2] = await Promise.all([promise1, promise2]);
+			expect(result1).toEqual(result2);
+		});
+
+		it("should allow a new authorize call after the previous one completes", async () => {
+			setupSuccessfulFlow();
+
+			const result1 = await adapter.authorize();
+			const result2 = await adapter.authorize();
+
+			// どちらも成功する（別々の呼び出し）
+			expect(result1).toEqual(MOCK_TOKEN);
+			expect(result2).toEqual(MOCK_TOKEN);
+		});
+
+		it("should use default tokenType 'bearer' when token_type is missing from response", async () => {
+			const chromeMock = getChromeMock();
+			chromeMock.identity.launchWebAuthFlow.mockImplementation(async (details: { url: string }) => {
+				const url = new URL(details.url);
+				const state = url.searchParams.get("state");
+				return `${TEST_CONFIG.redirectUri}?code=test-code&state=${state}`;
+			});
+
+			globalThis.fetch = vi.fn().mockResolvedValue({
+				ok: true,
+				json: async () => ({
+					access_token: "gho_test_token",
+					scope: "repo",
+					// token_type is intentionally omitted
+				}),
+			});
+
+			const result = await adapter.authorize();
+			expect(result.tokenType).toBe("bearer");
+		});
+
+		it("should use default empty string scope when scope is missing from response", async () => {
+			const chromeMock = getChromeMock();
+			chromeMock.identity.launchWebAuthFlow.mockImplementation(async (details: { url: string }) => {
+				const url = new URL(details.url);
+				const state = url.searchParams.get("state");
+				return `${TEST_CONFIG.redirectUri}?code=test-code&state=${state}`;
+			});
+
+			globalThis.fetch = vi.fn().mockResolvedValue({
+				ok: true,
+				json: async () => ({
+					access_token: "gho_test_token",
+					token_type: "bearer",
+					// scope is intentionally omitted
+				}),
+			});
+
+			const result = await adapter.authorize();
+			expect(result.scope).toBe("");
+		});
+
+		it("should throw AuthError when response body is invalid JSON", async () => {
+			const chromeMock = getChromeMock();
+			chromeMock.identity.launchWebAuthFlow.mockImplementation(async (details: { url: string }) => {
+				const url = new URL(details.url);
+				const state = url.searchParams.get("state");
+				return `${TEST_CONFIG.redirectUri}?code=test-code&state=${state}`;
+			});
+
+			globalThis.fetch = vi.fn().mockResolvedValue({
+				ok: true,
+				json: async () => {
+					throw new SyntaxError("Unexpected token < in JSON");
+				},
+			});
+
+			const error = await adapter.authorize().catch((e: unknown) => e);
+			expect(error).toBeInstanceOf(AuthError);
+			expect((error as AuthError).code).toBe("token_exchange_failed");
+			expect((error as AuthError).message).toContain("invalid response body");
+		});
+
+		it("should reset pending state after authorize fails", async () => {
+			const chromeMock = getChromeMock();
+			chromeMock.identity.launchWebAuthFlow.mockResolvedValueOnce(undefined);
+
+			await adapter.authorize().catch(() => {});
+
+			// 失敗後に再度呼び出せる
+			setupSuccessfulFlow();
+			const result = await adapter.authorize();
+			expect(result).toEqual(MOCK_TOKEN);
+		});
+	});
+
+	describe("getToken", () => {
+		it("should retrieve saved token from StoragePort", async () => {
+			mockStorage.get.mockResolvedValue(MOCK_TOKEN);
+
+			const result = await adapter.getToken();
+
+			expect(mockStorage.get).toHaveBeenCalledWith("github_auth_token");
+			expect(result).toEqual(MOCK_TOKEN);
+		});
+
+		it("should return null when no token is saved", async () => {
+			mockStorage.get.mockResolvedValue(null);
+
+			const result = await adapter.getToken();
+
+			expect(result).toBeNull();
+		});
+	});
+
+	describe("clearToken", () => {
+		it("should remove token from StoragePort", async () => {
+			await adapter.clearToken();
+
+			expect(mockStorage.remove).toHaveBeenCalledWith("github_auth_token");
+		});
+	});
+
+	describe("isAuthenticated", () => {
+		it("should return true when token exists", async () => {
+			mockStorage.get.mockResolvedValue(MOCK_TOKEN);
+
+			const result = await adapter.isAuthenticated();
+
+			expect(result).toBe(true);
+		});
+
+		it("should return false when no token exists", async () => {
+			mockStorage.get.mockResolvedValue(null);
+
+			const result = await adapter.isAuthenticated();
+
+			expect(result).toBe(false);
+		});
+	});
+});

--- a/src/test/adapter/chrome/storage.adapter.test.ts
+++ b/src/test/adapter/chrome/storage.adapter.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { ChromeStorageAdapter } from "../../../adapter/chrome/storage.adapter";
+import { getChromeMock, resetChromeMock, setupChromeMock } from "../../mocks/chrome.mock";
+
+describe("ChromeStorageAdapter", () => {
+	let adapter: ChromeStorageAdapter;
+
+	beforeEach(() => {
+		setupChromeMock();
+		adapter = new ChromeStorageAdapter();
+	});
+
+	afterEach(() => {
+		resetChromeMock();
+	});
+
+	describe("get", () => {
+		it("should call chrome.storage.local.get with the correct key", async () => {
+			const mock = getChromeMock();
+			mock.storage.local.get.mockResolvedValue({ myKey: "myValue" });
+
+			await adapter.get("myKey");
+
+			expect(mock.storage.local.get).toHaveBeenCalledWith("myKey");
+		});
+
+		it("should return the value for the given key", async () => {
+			const mock = getChromeMock();
+			mock.storage.local.get.mockResolvedValue({
+				myKey: { data: "test" },
+			});
+
+			const result = await adapter.get("myKey");
+
+			expect(result).toEqual({ data: "test" });
+		});
+
+		it("should return null when the key does not exist", async () => {
+			const mock = getChromeMock();
+			mock.storage.local.get.mockResolvedValue({});
+
+			const result = await adapter.get("nonExistent");
+
+			expect(result).toBeNull();
+		});
+	});
+
+	describe("set", () => {
+		it("should call chrome.storage.local.set with the correct arguments", async () => {
+			const mock = getChromeMock();
+			mock.storage.local.set.mockResolvedValue(undefined);
+
+			await adapter.set("myKey", { data: "test" });
+
+			expect(mock.storage.local.set).toHaveBeenCalledWith({
+				myKey: { data: "test" },
+			});
+		});
+	});
+
+	describe("remove", () => {
+		it("should call chrome.storage.local.remove with the correct key", async () => {
+			const mock = getChromeMock();
+			mock.storage.local.remove.mockResolvedValue(undefined);
+
+			await adapter.remove("myKey");
+
+			expect(mock.storage.local.remove).toHaveBeenCalledWith("myKey");
+		});
+	});
+});

--- a/src/test/background/bootstrap-auth.test.ts
+++ b/src/test/background/bootstrap-auth.test.ts
@@ -1,0 +1,32 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { resetChromeMock, setupChromeMock } from "../mocks/chrome.mock";
+
+describe("bootstrap with auth", () => {
+	beforeEach(() => {
+		setupChromeMock();
+		vi.stubEnv("VITE_GITHUB_CLIENT_ID", "test-client-id");
+		vi.stubEnv("VITE_GITHUB_CLIENT_SECRET", "test-client-secret");
+	});
+
+	afterEach(() => {
+		resetChromeMock();
+		vi.unstubAllEnvs();
+	});
+
+	it("should return an object with auth property", async () => {
+		const { initializeApp } = await import("../../background/bootstrap");
+		const app = initializeApp();
+
+		expect(app).toHaveProperty("auth");
+	});
+
+	it("should return auth with required methods", async () => {
+		const { initializeApp } = await import("../../background/bootstrap");
+		const app = initializeApp();
+
+		expect(typeof app.auth.authorize).toBe("function");
+		expect(typeof app.auth.getToken).toBe("function");
+		expect(typeof app.auth.clearToken).toBe("function");
+		expect(typeof app.auth.isAuthenticated).toBe("function");
+	});
+});

--- a/src/test/background/bootstrap.test.ts
+++ b/src/test/background/bootstrap.test.ts
@@ -1,10 +1,34 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { initializeApp } from "../../background/bootstrap";
+import { resetChromeMock, setupChromeMock } from "../mocks/chrome.mock";
 
 describe("bootstrap", () => {
+	beforeEach(() => {
+		setupChromeMock();
+		vi.stubEnv("VITE_GITHUB_CLIENT_ID", "test-client-id");
+		vi.stubEnv("VITE_GITHUB_CLIENT_SECRET", "test-client-secret");
+	});
+
+	afterEach(() => {
+		resetChromeMock();
+		vi.unstubAllEnvs();
+	});
+
 	describe("initializeApp", () => {
 		it("should complete without throwing", () => {
 			expect(() => initializeApp()).not.toThrow();
+		});
+
+		it("should return AppServices with auth", () => {
+			const services = initializeApp();
+			expect(services).toHaveProperty("auth");
+		});
+
+		it("should pass chrome.identity.getRedirectURL() as redirectUri", () => {
+			const services = initializeApp();
+			expect(services).toHaveProperty("auth");
+			// chrome.identity.getRedirectURL が呼ばれていることを確認
+			expect(chrome.identity.getRedirectURL).toHaveBeenCalled();
 		});
 	});
 });

--- a/src/test/mocks/chrome.mock.ts
+++ b/src/test/mocks/chrome.mock.ts
@@ -1,0 +1,48 @@
+import { vi } from "vitest";
+
+type ChromeMock = {
+	identity: {
+		launchWebAuthFlow: ReturnType<typeof vi.fn>;
+		getRedirectURL: ReturnType<typeof vi.fn>;
+	};
+	storage: {
+		local: {
+			get: ReturnType<typeof vi.fn>;
+			set: ReturnType<typeof vi.fn>;
+			remove: ReturnType<typeof vi.fn>;
+		};
+	};
+};
+
+let chromeMock: ChromeMock;
+
+function createChromeMock(): ChromeMock {
+	return {
+		identity: {
+			launchWebAuthFlow: vi.fn(),
+			getRedirectURL: vi.fn(() => "https://mock-redirect.chromiumapp.org/"),
+		},
+		storage: {
+			local: {
+				get: vi.fn(),
+				set: vi.fn(),
+				remove: vi.fn(),
+			},
+		},
+	};
+}
+
+export function setupChromeMock(): ChromeMock {
+	chromeMock = createChromeMock();
+	// globalThis に chrome をセット (型安全性より実用性を優先)
+	(globalThis as Record<string, unknown>).chrome = chromeMock;
+	return chromeMock;
+}
+
+export function resetChromeMock(): void {
+	(globalThis as Record<string, unknown>).chrome = undefined;
+}
+
+export function getChromeMock(): ChromeMock {
+	return chromeMock;
+}

--- a/src/test/shared/config/oauth.config.test.ts
+++ b/src/test/shared/config/oauth.config.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+describe("createOAuthConfig", () => {
+	afterEach(() => {
+		vi.unstubAllEnvs();
+	});
+
+	it("should throw when VITE_GITHUB_CLIENT_ID is not set", async () => {
+		vi.stubEnv("VITE_GITHUB_CLIENT_ID", "");
+		vi.stubEnv("VITE_GITHUB_CLIENT_SECRET", "test-secret");
+
+		const mod = await import("../../../shared/config/oauth.config");
+
+		expect(() => mod.createOAuthConfig("https://example.com/redirect")).toThrow(
+			"VITE_GITHUB_CLIENT_ID is not configured",
+		);
+	});
+
+	it("should throw when VITE_GITHUB_CLIENT_SECRET is not set", async () => {
+		vi.stubEnv("VITE_GITHUB_CLIENT_ID", "test-id");
+		vi.stubEnv("VITE_GITHUB_CLIENT_SECRET", "");
+
+		const mod = await import("../../../shared/config/oauth.config");
+
+		expect(() => mod.createOAuthConfig("https://example.com/redirect")).toThrow(
+			"VITE_GITHUB_CLIENT_SECRET is not configured",
+		);
+	});
+
+	it("should return OAuthConfig when credentials are set", async () => {
+		vi.stubEnv("VITE_GITHUB_CLIENT_ID", "test-client-id");
+		vi.stubEnv("VITE_GITHUB_CLIENT_SECRET", "test-client-secret");
+
+		const mod = await import("../../../shared/config/oauth.config");
+		const config = mod.createOAuthConfig("https://mock-redirect.chromiumapp.org/");
+
+		expect(config).toEqual({
+			clientId: "test-client-id",
+			clientSecret: "test-client-secret",
+			authorizationEndpoint: "https://github.com/login/oauth/authorize",
+			tokenEndpoint: "https://github.com/login/oauth/access_token",
+			redirectUri: "https://mock-redirect.chromiumapp.org/",
+			scopes: ["repo"],
+		});
+	});
+
+	it("should use the provided redirectUri", async () => {
+		vi.stubEnv("VITE_GITHUB_CLIENT_ID", "test-id");
+		vi.stubEnv("VITE_GITHUB_CLIENT_SECRET", "test-secret");
+
+		const mod = await import("../../../shared/config/oauth.config");
+		const config = mod.createOAuthConfig("https://custom-redirect.example.com/");
+
+		expect(config.redirectUri).toBe("https://custom-redirect.example.com/");
+	});
+});

--- a/src/test/shared/crypto.test.ts
+++ b/src/test/shared/crypto.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { generateCodeChallenge, generateCodeVerifier, generateState } from "../../shared/crypto";
+
+describe("crypto", () => {
+	describe("generateState", () => {
+		it("should return a string of at least 32 characters", () => {
+			const state = generateState();
+			expect(state.length).toBeGreaterThanOrEqual(32);
+		});
+
+		it("should return different values on consecutive calls", () => {
+			const state1 = generateState();
+			const state2 = generateState();
+			expect(state1).not.toBe(state2);
+		});
+	});
+
+	describe("generateCodeVerifier", () => {
+		it("should return a string between 43 and 128 characters", () => {
+			const verifier = generateCodeVerifier();
+			expect(verifier.length).toBeGreaterThanOrEqual(43);
+			expect(verifier.length).toBeLessThanOrEqual(128);
+		});
+
+		it("should contain only unreserved characters per RFC 7636", () => {
+			const verifier = generateCodeVerifier();
+			// RFC 7636: ALPHA / DIGIT / "-" / "." / "_" / "~"
+			expect(verifier).toMatch(/^[A-Za-z0-9\-._~]+$/);
+		});
+	});
+
+	describe("generateCodeChallenge", () => {
+		it("should return a Base64URL encoded string without padding", async () => {
+			const verifier = generateCodeVerifier();
+			const challenge = await generateCodeChallenge(verifier);
+
+			// Base64URL: A-Z, a-z, 0-9, -, _ のみ。+ / = は含まない
+			expect(challenge).toMatch(/^[A-Za-z0-9\-_]+$/);
+			expect(challenge).not.toContain("=");
+			expect(challenge).not.toContain("+");
+			expect(challenge).not.toContain("/");
+		});
+	});
+});


### PR DESCRIPTION
## 概要
GitHub OAuth 認証フローを Port + Adapter パターンで実装。AuthPort interface を Domain 層に定義し、ChromeIdentityAdapter で chrome.identity.launchWebAuthFlow を使った OAuth フローを実装した。

## 変更内容
- `src/domain/ports/auth.port.ts`: AuthPort interface (authorize, getToken, clearToken, isAuthenticated)
- `src/domain/ports/storage.port.ts`: StoragePort interface (get, set, remove)
- `src/adapter/chrome/identity.adapter.ts`: ChromeIdentityAdapter (OAuth フロー本体)
- `src/adapter/chrome/storage.adapter.ts`: ChromeStorageAdapter (chrome.storage.local ラップ)
- `src/shared/types/auth.ts`: OAuthConfig, AuthToken, AuthError 型定義
- `src/shared/crypto.ts`: PKCE / CSRF 暗号ユーティリティ
- `src/shared/config/oauth.config.ts`: OAuth 設定ファクトリ (環境変数から読み込み)
- `src/background/bootstrap.ts`: Composition Root に Adapter 注入追加
- `src/test/mocks/chrome.mock.ts`: Chrome API モック基盤
- `.env.example`: 環境変数テンプレート

## 関連 Issue
- closes #6

## テスト
- [x] TypeScript 型チェック通過 (`pnpm check`)
- [x] フロントエンドテスト通過 (`pnpm test`) — 50テスト
- [x] Rust lint 通過 (`cargo clippy --all-targets`)
- [x] Rust テスト通過 (`cargo test`)
- [x] `/verify` で検証ループ PASS

## レビュー観点
- PKCE (S256) + state パラメータによる CSRF 防止の実装
- GitHub token endpoint の 200 + error body ケースへの対応
- rejection sampling による code_verifier の modulo bias 排除
- authorize() の並行呼び出しガード
- Port/Adapter の依存方向 (Adapter → Port)