### PR TITLE
fix: GitHub Actions のアクション SHA 固定化 + Dependabot 設定

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,20 +15,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
         with:
           components: rustfmt, clippy
 
       - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           workspaces: "rust-core -> target"
 
       - name: Install cargo tools
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@06203676c62f0d3c765be3f2fcfbebbcb02d09f5 # v2
         with:
           tool: cargo-machete,cargo-audit,wasm-pack
 
@@ -61,24 +61,24 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4
         with:
           version: 10
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
           cache: 'pnpm'
 
       - name: Setup Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
 
       - name: Install wasm-pack
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@06203676c62f0d3c765be3f2fcfbebbcb02d09f5 # v2
         with:
           tool: wasm-pack
 


### PR DESCRIPTION
## 概要
CI ワークフローで使用している全 GitHub Actions のバージョン指定をタグ/ブランチ固定から SHA 固定に移行し、Supply chain attack 対策を強化。合わせて Dependabot による GitHub Actions の週次自動更新を設定し、セキュリティパッチの適用漏れを防止する。

## 変更内容
- `.github/workflows/ci.yml`: 全9箇所の `uses:` 参照を SHA 固定 + コメント形式に変更
  - `actions/checkout@v4` → SHA 固定 (2箇所)
  - `dtolnay/rust-toolchain@stable` → SHA 固定 (2箇所)
  - `Swatinem/rust-cache@v2` → SHA 固定 (1箇所)
  - `taiki-e/install-action@v2` → SHA 固定 (2箇所)
  - `pnpm/action-setup@v4` → SHA 固定 (1箇所)
  - `actions/setup-node@v4` → SHA 固定 (1箇所)
- `.github/dependabot.yml`: 新規作成。`github-actions` エコシステムの週次自動更新を設定

## 関連 Issue
- closes #22

## テスト
- [x] TypeScript 型チェック通過 (`pnpm check`)
- [x] フロントエンドテスト通過 (`pnpm test`)
- [x] Rust lint 通過 (`cargo clippy --all-targets`)
- [x] Rust テスト通過 (`cargo test`)
- [x] `/verify` で検証ループ PASS

## レビュー観点
- 各アクションの SHA が正しいタグ/ブランチのコミットを指しているか
- `dependabot.yml` の設定が適切か（`github-actions` エコシステムのみ、週次更新）
- CI の挙動に変化がないことの確認（SHA 固定は同一バージョンへの参照なので挙動は同一）