### PR TITLE
ci: WASM ビルド成果物を artifact 経由で Rust→TS ジョブ間受け渡し

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,12 +56,26 @@ jobs:
         run: wasm-pack build --target web --dev
         working-directory: rust-core/crates/adapter-wasm
 
+      - name: Upload WASM artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: wasm-pkg
+          path: rust-core/crates/adapter-wasm/pkg/
+          retention-days: 1
+
   typescript:
     name: TypeScript
     runs-on: ubuntu-latest
+    needs: [rust]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Download WASM artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: wasm-pkg
+          path: rust-core/crates/adapter-wasm/pkg/
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -73,18 +87,6 @@ jobs:
         with:
           node-version: 22
           cache: 'pnpm'
-
-      - name: Setup Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Install wasm-pack
-        uses: taiki-e/install-action@v2
-        with:
-          tool: wasm-pack
-
-      - name: Build WASM
-        run: wasm-pack build --target web --dev
-        working-directory: rust-core/crates/adapter-wasm
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
## 概要
CI の Rust ジョブと TypeScript ジョブ間で WASM ビルド成果物 (pkg/) の依存関係を正しく表現するため、artifact 経由の受け渡しに変更した。これにより WASM ビルドの二重実行を排除し、Rust ジョブの失敗が TS ジョブに確実に伝播するようになった。

## 変更内容
- `.github/workflows/ci.yml`: Rust ジョブ末尾に `actions/upload-artifact@v4` で WASM 成果物をアップロードするステップを追加
- `.github/workflows/ci.yml`: TypeScript ジョブに `needs: [rust]` を追加し、Rust ジョブへの依存を明示
- `.github/workflows/ci.yml`: TypeScript ジョブに `actions/download-artifact@v4` で WASM 成果物をダウンロードするステップを追加
- `.github/workflows/ci.yml`: TypeScript ジョブから Rust toolchain セットアップ、wasm-pack インストール、WASM ビルドの3ステップを削除

## 関連 Issue
- closes #25

## テスト
- [x] TypeScript 型チェック通過 (`pnpm check`)
- [x] フロントエンドテスト通過 (`pnpm test`)
- [x] Rust lint 通過 (`cargo clippy --all-targets`)
- [x] Rust テスト通過 (`cargo test`)
- [x] `/verify` で検証ループ PASS

## レビュー観点
- artifact の upload/download パス (`rust-core/crates/adapter-wasm/pkg/`) が TS 側の import パスと整合しているか
- `needs: [rust]` による逐次実行のトレードオフ（wall time 増加 vs WASM ビルド重複排除）が許容範囲か
- `retention-days: 1` が CI 用途として適切か