### PR TITLE
feat: AuthTokenに有効期限・リフレッシュトークン対応を追加

### DIFF
--- a/src/adapter/chrome/identity.adapter.ts
+++ b/src/adapter/chrome/identity.adapter.ts
@@ -34,7 +34,13 @@ export class ChromeIdentityAdapter implements AuthPort {
 
 	async isAuthenticated(): Promise<boolean> {
 		const token = await this.getToken();
-		return token !== null;
+		if (token === null) {
+			return false;
+		}
+		if (token.expiresAt !== undefined && Date.now() >= token.expiresAt) {
+			return false;
+		}
+		return true;
 	}
 
 	private async executeAuthFlow(): Promise<AuthToken> {
@@ -166,10 +172,18 @@ export class ChromeIdentityAdapter implements AuthPort {
 			throw new AuthError("token_exchange_failed", "Invalid token response: missing access_token");
 		}
 
-		return {
+		const token: AuthToken = {
 			accessToken: data.access_token,
 			tokenType: typeof data.token_type === "string" ? data.token_type : "bearer",
 			scope: typeof data.scope === "string" ? data.scope : "",
+			// expires_in が 0 以下や Infinity の場合は「期限なし」として expiresAt を設定しない
+			...(typeof data.expires_in === "number" &&
+			Number.isFinite(data.expires_in) &&
+			data.expires_in > 0
+				? { expiresAt: Date.now() + data.expires_in * 1000 }
+				: {}),
+			...(typeof data.refresh_token === "string" ? { refreshToken: data.refresh_token } : {}),
 		};
+		return token;
 	}
 }

--- a/src/shared/types/auth.ts
+++ b/src/shared/types/auth.ts
@@ -11,6 +11,8 @@ export type AuthToken = {
 	readonly accessToken: string;
 	readonly tokenType: string;
 	readonly scope: string;
+	readonly expiresAt?: number;
+	readonly refreshToken?: string;
 };
 
 export type AuthErrorCode =

--- a/src/test/adapter/chrome/identity.adapter.test.ts
+++ b/src/test/adapter/chrome/identity.adapter.test.ts
@@ -47,6 +47,7 @@ describe("ChromeIdentityAdapter", () => {
 	});
 
 	afterEach(() => {
+		vi.useRealTimers();
 		resetChromeMock();
 		globalThis.fetch = originalFetch;
 	});
@@ -347,6 +348,78 @@ describe("ChromeIdentityAdapter", () => {
 			const result = await adapter.authorize();
 			expect(result).toEqual(MOCK_TOKEN);
 		});
+
+		it("should set expiresAt when expires_in is present in response", async () => {
+			vi.useFakeTimers();
+			vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+
+			const chromeMock = getChromeMock();
+			chromeMock.identity.launchWebAuthFlow.mockImplementation(async (details: { url: string }) => {
+				const url = new URL(details.url);
+				const state = url.searchParams.get("state");
+				return `${TEST_CONFIG.redirectUri}?code=test-auth-code&state=${state}`;
+			});
+
+			globalThis.fetch = vi.fn().mockResolvedValue({
+				ok: true,
+				json: async () => ({
+					access_token: "gho_test_access_token",
+					token_type: "bearer",
+					scope: "repo",
+					expires_in: 3600,
+				}),
+			});
+
+			await adapter.authorize();
+
+			const savedToken = mockStorage.set.mock.calls[0][1] as AuthToken;
+			const expectedExpiresAt = new Date("2026-01-01T00:00:00Z").getTime() + 3600 * 1000;
+			expect(savedToken.expiresAt).toBe(expectedExpiresAt);
+
+			vi.useRealTimers();
+		});
+
+		it("should set refreshToken when refresh_token is present in response", async () => {
+			const chromeMock = getChromeMock();
+			chromeMock.identity.launchWebAuthFlow.mockImplementation(async (details: { url: string }) => {
+				const url = new URL(details.url);
+				const state = url.searchParams.get("state");
+				return `${TEST_CONFIG.redirectUri}?code=test-auth-code&state=${state}`;
+			});
+
+			globalThis.fetch = vi.fn().mockResolvedValue({
+				ok: true,
+				json: async () => ({
+					access_token: "gho_test_access_token",
+					token_type: "bearer",
+					scope: "repo",
+					refresh_token: "ghr_xxx",
+				}),
+			});
+
+			await adapter.authorize();
+
+			const savedToken = mockStorage.set.mock.calls[0][1] as AuthToken;
+			expect(savedToken.refreshToken).toBe("ghr_xxx");
+		});
+
+		it("should omit expiresAt when expires_in is not present", async () => {
+			setupSuccessfulFlow();
+
+			await adapter.authorize();
+
+			const savedToken = mockStorage.set.mock.calls[0][1] as Record<string, unknown>;
+			expect(savedToken.expiresAt).toBeUndefined();
+		});
+
+		it("should omit refreshToken when refresh_token is not present", async () => {
+			setupSuccessfulFlow();
+
+			await adapter.authorize();
+
+			const savedToken = mockStorage.set.mock.calls[0][1] as Record<string, unknown>;
+			expect(savedToken.refreshToken).toBeUndefined();
+		});
 	});
 
 	describe("getToken", () => {
@@ -391,6 +464,66 @@ describe("ChromeIdentityAdapter", () => {
 			const result = await adapter.isAuthenticated();
 
 			expect(result).toBe(false);
+		});
+
+		it("should return true when token exists without expiresAt (non-expiring)", async () => {
+			// expiresAt がないトークンは期限なしとして true を返すべき
+			mockStorage.get.mockResolvedValue({
+				...MOCK_TOKEN,
+			});
+
+			const result = await adapter.isAuthenticated();
+
+			expect(result).toBe(true);
+		});
+
+		it("should return true when token exists and expiresAt is in the future", async () => {
+			vi.useFakeTimers();
+			vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+
+			const futureExpiresAt = new Date("2026-01-01T00:00:00Z").getTime() + 3600 * 1000;
+			mockStorage.get.mockResolvedValue({
+				...MOCK_TOKEN,
+				expiresAt: futureExpiresAt,
+			});
+
+			const result = await adapter.isAuthenticated();
+
+			expect(result).toBe(true);
+
+			vi.useRealTimers();
+		});
+
+		it("should return false when token expiresAt equals current time (boundary)", async () => {
+			vi.useFakeTimers();
+			vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+
+			const exactNow = new Date("2026-01-01T00:00:00Z").getTime();
+			mockStorage.get.mockResolvedValue({
+				...MOCK_TOKEN,
+				expiresAt: exactNow,
+			});
+
+			const result = await adapter.isAuthenticated();
+
+			expect(result).toBe(false);
+		});
+
+		it("should return false when token exists but expiresAt is in the past", async () => {
+			vi.useFakeTimers();
+			vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+
+			const pastExpiresAt = new Date("2026-01-01T00:00:00Z").getTime() - 1000;
+			mockStorage.get.mockResolvedValue({
+				...MOCK_TOKEN,
+				expiresAt: pastExpiresAt,
+			});
+
+			const result = await adapter.isAuthenticated();
+
+			expect(result).toBe(false);
+
+			vi.useRealTimers();
 		});
 	});
 });


### PR DESCRIPTION
## 概要
AuthToken 型に expiresAt と refreshToken フィールドを追加し、isAuthenticated() でトークン有効期限チェックを実装した。将来的なトークンローテーション対応の基盤となる変更。

## 変更内容
- `src/shared/types/auth.ts`: AuthToken に `readonly expiresAt?: number` と `readonly refreshToken?: string` を追加
- `src/adapter/chrome/identity.adapter.ts`: `validateTokenData()` で `expires_in` → `expiresAt` (ms) 変換と `refresh_token` → `refreshToken` マッピングを追加。`isAuthenticated()` で `Date.now() >= expiresAt` による期限切れチェックを追加。`Number.isFinite` ガードで Infinity 混入を防止
- `src/test/adapter/chrome/identity.adapter.test.ts`: 有効期限・リフレッシュトークン関連のテスト 8 ケースを追加（expiresAt 設定/省略、refreshToken 設定/省略、期限切れ/有効/境界値）

## 関連 Issue
- closes #26

## テスト
- [x] TypeScript 型チェック通過 (`pnpm check`)
- [x] フロントエンドテスト通過 (`pnpm test`) — 121 tests passed
- [x] Rust lint 通過 (`cargo clippy --all-targets`)
- [x] Rust テスト通過 (`cargo test`) — 28 tests passed
- [x] `/verify` で検証ループ PASS

## レビュー観点
- `expiresAt` が undefined の場合を「無期限 = 有効」として扱う設計判断の妥当性
- `expires_in <= 0` を「期限なし」として扱うガード条件の妥当性
- `Date.now() >= expiresAt` の境界条件（ちょうど期限 = 期限切れ）の仕様
- 既存テストへの影響がないこと（optional フィールド追加のため後方互換）