### PR TITLE
feat: StoragePort.getに型ガードバリデーションを追加

### DIFF
--- a/src/adapter/chrome/identity.adapter.ts
+++ b/src/adapter/chrome/identity.adapter.ts
@@ -2,7 +2,7 @@ import type { AuthPort } from "../../domain/ports/auth.port";
 import type { StoragePort } from "../../domain/ports/storage.port";
 import { generateCodeChallenge, generateCodeVerifier, generateState } from "../../shared/crypto";
 import type { AuthToken, OAuthConfig } from "../../shared/types/auth";
-import { AuthError } from "../../shared/types/auth";
+import { AuthError, isAuthToken } from "../../shared/types/auth";
 
 const TOKEN_STORAGE_KEY = "github_auth_token";
 
@@ -25,7 +25,7 @@ export class ChromeIdentityAdapter implements AuthPort {
 	}
 
 	async getToken(): Promise<AuthToken | null> {
-		return this.storage.get<AuthToken>(TOKEN_STORAGE_KEY);
+		return this.storage.get<AuthToken>(TOKEN_STORAGE_KEY, isAuthToken);
 	}
 
 	async clearToken(): Promise<void> {

--- a/src/adapter/chrome/storage.adapter.ts
+++ b/src/adapter/chrome/storage.adapter.ts
@@ -1,10 +1,17 @@
 import type { StoragePort } from "../../domain/ports/storage.port";
 
 export class ChromeStorageAdapter implements StoragePort {
-	async get<T>(key: string): Promise<T | null> {
+	async get<T>(key: string, validate: (value: unknown) => value is T): Promise<T | null> {
 		const result = await chrome.storage.local.get(key);
-		if (key in result) {
-			return result[key] as T;
+		if (!(key in result)) {
+			return null;
+		}
+		const value: unknown = result[key];
+		if (validate(value)) {
+			return value;
+		}
+		if (import.meta.env.DEV) {
+			console.warn(`[storage] validation failed for key "${key}"`);
 		}
 		return null;
 	}

--- a/src/domain/ports/storage.port.ts
+++ b/src/domain/ports/storage.port.ts
@@ -1,5 +1,10 @@
 export interface StoragePort {
-	get<T>(key: string): Promise<T | null>;
+	/**
+	 * ストレージから値を取得し、型ガードで検証する。
+	 * バリデーション成功時のみ値を返し、失敗時は null を返す。
+	 * ストレージアクセスエラーは例外として上位に伝播する。
+	 */
+	get<T>(key: string, validate: (value: unknown) => value is T): Promise<T | null>;
 	set<T>(key: string, value: T): Promise<void>;
 	remove(key: string): Promise<void>;
 }

--- a/src/shared/types/auth.ts
+++ b/src/shared/types/auth.ts
@@ -13,6 +13,20 @@ export type AuthToken = {
 	readonly scope: string;
 };
 
+export function isAuthToken(value: unknown): value is AuthToken {
+	if (typeof value !== "object" || value === null) {
+		return false;
+	}
+	const obj = value as Record<string, unknown>;
+	return (
+		typeof obj.accessToken === "string" &&
+		obj.accessToken !== "" &&
+		typeof obj.tokenType === "string" &&
+		obj.tokenType !== "" &&
+		typeof obj.scope === "string"
+	);
+}
+
 export type AuthErrorCode =
 	| "authorization_failed"
 	| "token_exchange_failed"

--- a/src/test/adapter/chrome/identity.adapter.test.ts
+++ b/src/test/adapter/chrome/identity.adapter.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ChromeIdentityAdapter } from "../../../adapter/chrome/identity.adapter";
 import type { StoragePort } from "../../../domain/ports/storage.port";
 import type { AuthToken, OAuthConfig } from "../../../shared/types/auth";
-import { AuthError } from "../../../shared/types/auth";
+import { AuthError, isAuthToken } from "../../../shared/types/auth";
 import { getChromeMock, resetChromeMock, setupChromeMock } from "../../mocks/chrome.mock";
 
 function createMockStorage(): StoragePort & {
@@ -355,7 +355,7 @@ describe("ChromeIdentityAdapter", () => {
 
 			const result = await adapter.getToken();
 
-			expect(mockStorage.get).toHaveBeenCalledWith("github_auth_token");
+			expect(mockStorage.get).toHaveBeenCalledWith("github_auth_token", isAuthToken);
 			expect(result).toEqual(MOCK_TOKEN);
 		});
 

--- a/src/test/adapter/chrome/storage.adapter.test.ts
+++ b/src/test/adapter/chrome/storage.adapter.test.ts
@@ -1,9 +1,10 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ChromeStorageAdapter } from "../../../adapter/chrome/storage.adapter";
+import type { StoragePort } from "../../../domain/ports/storage.port";
 import { getChromeMock, resetChromeMock, setupChromeMock } from "../../mocks/chrome.mock";
 
 describe("ChromeStorageAdapter", () => {
-	let adapter: ChromeStorageAdapter;
+	let adapter: StoragePort;
 
 	beforeEach(() => {
 		setupChromeMock();
@@ -15,33 +16,57 @@ describe("ChromeStorageAdapter", () => {
 	});
 
 	describe("get", () => {
+		const alwaysTrue = (_v: unknown): _v is unknown => true;
+
 		it("should call chrome.storage.local.get with the correct key", async () => {
 			const mock = getChromeMock();
 			mock.storage.local.get.mockResolvedValue({ myKey: "myValue" });
 
-			await adapter.get("myKey");
+			await adapter.get("myKey", alwaysTrue);
 
 			expect(mock.storage.local.get).toHaveBeenCalledWith("myKey");
 		});
 
-		it("should return the value for the given key", async () => {
+		it("should return the value when validation succeeds", async () => {
 			const mock = getChromeMock();
 			mock.storage.local.get.mockResolvedValue({
 				myKey: { data: "test" },
 			});
+			const validate = (_v: unknown): _v is { data: string } => true;
 
-			const result = await adapter.get("myKey");
+			const result = await adapter.get("myKey", validate);
 
 			expect(result).toEqual({ data: "test" });
 		});
 
-		it("should return null when the key does not exist", async () => {
+		it("should return null when validation fails", async () => {
 			const mock = getChromeMock();
-			mock.storage.local.get.mockResolvedValue({});
+			mock.storage.local.get.mockResolvedValue({
+				myKey: { data: "test" },
+			});
+			const validate = (_v: unknown): _v is never => false;
+			const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 
-			const result = await adapter.get("nonExistent");
+			const result = await adapter.get("myKey", validate);
 
 			expect(result).toBeNull();
+			expect(warnSpy).toHaveBeenCalledWith('[storage] validation failed for key "myKey"');
+			warnSpy.mockRestore();
+		});
+
+		it("should return null when the key does not exist without calling validate", async () => {
+			const mock = getChromeMock();
+			mock.storage.local.get.mockResolvedValue({});
+			let validateCalled = false;
+			const validate = (_v: unknown): _v is unknown => {
+				validateCalled = true;
+				return true;
+			};
+
+			const result = await adapter.get("nonExistent", validate);
+
+			expect(result).toBeNull();
+			expect(validateCalled).toBe(false);
 		});
 	});
 

--- a/src/test/shared/types/validators.test.ts
+++ b/src/test/shared/types/validators.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import type { AuthToken } from "../../../shared/types/auth";
+import { isAuthToken } from "../../../shared/types/auth";
+
+describe("isAuthToken", () => {
+	const validToken: AuthToken = {
+		accessToken: "gho_abc123",
+		tokenType: "bearer",
+		scope: "repo",
+	};
+
+	it("should return true for a valid AuthToken object", () => {
+		expect(isAuthToken(validToken)).toBe(true);
+	});
+
+	it("should return false when accessToken is empty string", () => {
+		expect(isAuthToken({ ...validToken, accessToken: "" })).toBe(false);
+	});
+
+	it("should return false when accessToken is missing", () => {
+		const { accessToken: _, ...rest } = validToken;
+		expect(isAuthToken(rest)).toBe(false);
+	});
+
+	it("should return false when tokenType is missing", () => {
+		const { tokenType: _, ...rest } = validToken;
+		expect(isAuthToken(rest)).toBe(false);
+	});
+
+	it("should return false when scope is missing", () => {
+		const { scope: _, ...rest } = validToken;
+		expect(isAuthToken(rest)).toBe(false);
+	});
+
+	it("should return false for null", () => {
+		expect(isAuthToken(null)).toBe(false);
+	});
+
+	it("should return false for undefined", () => {
+		expect(isAuthToken(undefined)).toBe(false);
+	});
+
+	it("should return false for a string", () => {
+		expect(isAuthToken("some-token")).toBe(false);
+	});
+
+	it("should return false for a number", () => {
+		expect(isAuthToken(42)).toBe(false);
+	});
+
+	it("should return true when extra properties exist (structural typing)", () => {
+		expect(isAuthToken({ ...validToken, extra: "field" })).toBe(true);
+	});
+
+	it("should return true when scope is empty string", () => {
+		expect(isAuthToken({ ...validToken, scope: "" })).toBe(true);
+	});
+
+	it("should return false when tokenType is empty string", () => {
+		expect(isAuthToken({ ...validToken, tokenType: "" })).toBe(false);
+	});
+
+	it("should return false when accessToken is a number instead of string", () => {
+		expect(isAuthToken({ accessToken: 123, tokenType: "bearer", scope: "repo" })).toBe(false);
+	});
+
+	it("should return false when tokenType is a boolean instead of string", () => {
+		expect(isAuthToken({ accessToken: "token", tokenType: true, scope: "repo" })).toBe(false);
+	});
+
+	it("should return false when scope is null instead of string", () => {
+		expect(isAuthToken({ accessToken: "token", tokenType: "bearer", scope: null })).toBe(false);
+	});
+
+	it("should validate all AuthToken fields (guard against type drift)", () => {
+		const token: AuthToken = { accessToken: "x", tokenType: "bearer", scope: "" };
+		const keys = Object.keys(token);
+		expect(keys).toHaveLength(3);
+	});
+});


### PR DESCRIPTION
## 概要
`StoragePort.get<T>` の `as T` キャストを除去し、型ガード関数 (`validate`) パラメータで実行時型検証を行うように変更。スキーマ変更時の実行時エラーを早期に検出可能にする。

## 変更内容
- `src/domain/ports/storage.port.ts`: `get<T>` シグネチャに `validate` パラメータ追加 + JSDoc
- `src/adapter/chrome/storage.adapter.ts`: `as T` キャスト除去、`validate` 関数で型検証、失敗時 `console.warn`（DEV のみ）
- `src/shared/types/auth.ts`: `isAuthToken` 型ガード関数追加（AuthToken の実行時検証）
- `src/adapter/chrome/identity.adapter.ts`: `getToken()` で `isAuthToken` を使用
- `src/test/shared/types/validators.test.ts`: `isAuthToken` の網羅的テスト（16件、型ドリフト検知含む）
- `src/test/adapter/chrome/storage.adapter.test.ts`: バリデーション成功/失敗/キー不在のテスト追加
- `src/test/adapter/chrome/identity.adapter.test.ts`: mock 型・アサーション更新

## 関連 Issue
- closes #27

## テスト
- [x] TypeScript 型チェック通過 (`pnpm check`)
- [x] フロントエンドテスト通過 (`pnpm test`) — 130件全PASS
- [x] Rust lint 通過 (`cargo clippy --all-targets`)
- [x] Rust テスト通過 (`cargo test`)
- [x] `/verify` で検証ループ PASS

## レビュー観点
- `StoragePort.get` のシグネチャ変更が破壊的変更であるため、全呼び出し箇所が正しく更新されているか
- `isAuthToken` の型ガードが `AuthToken` 型の全フィールドを正しく検証しているか（特に `scope` 空文字許容の設計判断）
- バリデーション失敗時の `null` 返却 + `console.warn`（DEV のみ）がサイレントフォールバック禁止ルールに適合しているか