### PR TITLE
chore: settings.json の gh auth/api 許可スコープを絞る

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -7,10 +7,19 @@
 			"Bash(gh repo:*)",
 			"Bash(gh issue:*)",
 			"Bash(gh label:*)",
-			"Bash(gh auth:*)",
-			"Bash(gh api:*)"
+			"Bash(gh auth status:*)",
+			"Bash(gh api graphql:*)",
+			"Bash(gh api repos/:*)",
+			"Bash(gh api /repos/:*)",
+			"Bash(gh api -X DELETE repos/:*)",
+			"Bash(gh api -X DELETE /repos/:*)"
 		],
 		"deny": [
+			"Bash(gh auth token:*)",
+			"Bash(gh auth login:*)",
+			"Bash(gh auth logout:*)",
+			"Bash(gh auth refresh:*)",
+			"Bash(gh auth setup-git:*)",
 			"Read(.envrc)",
 			"Read(.claude/settings.local.json)",
 			"Bash(cat .envrc)",


### PR DESCRIPTION
## 概要
`.claude/settings.json` の `gh auth:*` と `gh api:*` の許可スコープが広すぎるため、最小権限の原則に基づいて必要最小限に絞り込んだ。

## 変更内容
- `.claude/settings.json`: allow リストの `gh auth:*` → `gh auth status:*` に制限
- `.claude/settings.json`: allow リストの `gh api:*` → `gh api graphql:*`, `gh api repos/:*`, `gh api /repos/:*`, `gh api -X DELETE repos/:*`, `gh api -X DELETE /repos/:*` に分割
- `.claude/settings.json`: deny リストに `gh auth token/login/logout/refresh/setup-git` を追加（二重防御）

## 関連 Issue
- closes #19

## テスト
- [x] TypeScript 型チェック通過 (`pnpm check`)
- [x] フロントエンドテスト通過 (`pnpm test`)
- [x] Rust lint 通過 (`cargo clippy --all-targets`)
- [x] Rust テスト通過 (`cargo test`)
- [x] `/verify` で検証ループ PASS

## レビュー観点
- Claude Code の `Bash()` パーミッションパターンマッチが `:*` で前方一致する前提で設計している。実際に `gh api graphql -f query=...` 等のコマンドが許可されることを動作確認してほしい
- `gh api -X DELETE repos/...` のフラグ順序がパターンマッチに影響しないか確認してほしい
- スコープ外の関連 Issue (#70, #71, #72, #73, #74, #75) の優先度判断