### PR TITLE
refactor: domain 層の shared 依存を逆転させる

### DIFF
--- a/src/adapter/chrome/identity.adapter.ts
+++ b/src/adapter/chrome/identity.adapter.ts
@@ -1,11 +1,7 @@
 import type { AuthPort } from "../../domain/ports/auth.port";
 import type { StoragePort } from "../../domain/ports/storage.port";
-import type {
-	AuthToken,
-	DeviceCodeResponse,
-	OAuthConfig,
-	PollResult,
-} from "../../shared/types/auth";
+import type { AuthToken, DeviceCodeResponse, PollResult } from "../../domain/types/auth";
+import type { OAuthConfig } from "../../shared/types/auth";
 import { AuthError, isAuthToken } from "../../shared/types/auth";
 
 const TOKEN_STORAGE_KEY = "github_auth_token";

--- a/src/adapter/github/graphql-client.ts
+++ b/src/adapter/github/graphql-client.ts
@@ -1,11 +1,11 @@
 import type { GitHubApiPort } from "../../domain/ports/github-api.port";
-import { GitHubApiError } from "../../shared/types/errors";
 import type {
 	FetchPullRequestsResult,
 	PullRequest,
 	ReviewDecision,
 	StatusState,
-} from "../../shared/types/github";
+} from "../../domain/types/github";
+import { GitHubApiError } from "../../shared/types/errors";
 
 const GRAPHQL_ENDPOINT = "https://api.github.com/graphql";
 

--- a/src/shared/types/auth.ts
+++ b/src/shared/types/auth.ts
@@ -6,7 +6,6 @@ export type OAuthConfig = {
 };
 
 import type { AuthToken } from "../../domain/types/auth";
-export type { AuthToken, DeviceCodeResponse, PollResult } from "../../domain/types/auth";
 
 export function isAuthToken(value: unknown): value is AuthToken {
 	if (typeof value !== "object" || value === null) {

--- a/src/shared/types/github.ts
+++ b/src/shared/types/github.ts
@@ -1,6 +1,0 @@
-export type {
-	FetchPullRequestsResult,
-	PullRequest,
-	ReviewDecision,
-	StatusState,
-} from "../../domain/types/github";

--- a/src/shared/types/messages.ts
+++ b/src/shared/types/messages.ts
@@ -1,4 +1,4 @@
-import type { DeviceCodeResponse, PollResult } from "./auth";
+import type { DeviceCodeResponse, PollResult } from "../../domain/types/auth";
 
 export const MESSAGE_TYPES = [
 	"AUTH_LOGOUT",

--- a/src/sidepanel/usecase/auth.usecase.ts
+++ b/src/sidepanel/usecase/auth.usecase.ts
@@ -1,5 +1,5 @@
+import type { DeviceCodeResponse, PollResult } from "../../domain/types/auth";
 import type { SendMessage } from "../../shared/ports/message.port";
-import type { DeviceCodeResponse, PollResult } from "../../shared/types/auth";
 
 /** Side Panel 側のポーリング間隔下限 (秒) */
 const MIN_POLL_INTERVAL_SEC = 5;

--- a/src/test/adapter/chrome/identity.adapter.test.ts
+++ b/src/test/adapter/chrome/identity.adapter.test.ts
@@ -1,9 +1,62 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ChromeIdentityAdapter } from "../../../adapter/chrome/identity.adapter";
 import type { StoragePort } from "../../../domain/ports/storage.port";
-import type { AuthToken, DeviceCodeResponse, OAuthConfig } from "../../../shared/types/auth";
+import type { AuthToken, DeviceCodeResponse } from "../../../domain/types/auth";
+import type { OAuthConfig } from "../../../shared/types/auth";
 import { AuthError, isAuthToken } from "../../../shared/types/auth";
 import { getChromeMock, resetChromeMock, setupChromeMock } from "../../mocks/chrome.mock";
+
+describe("identity.adapter の依存方向", () => {
+	it("AuthToken, DeviceCodeResponse, PollResult を domain/types/auth から直接 import していること", () => {
+		const files = import.meta.glob("../../../adapter/chrome/identity.adapter.ts", {
+			query: "?raw",
+			eager: true,
+		}) as Record<string, { default: string }>;
+
+		const matchedPaths = Object.keys(files);
+		expect(matchedPaths, "adapter/chrome/identity.adapter.ts が見つかりません").toHaveLength(1);
+
+		const content = Object.values(files)[0]?.default;
+		expect(content).toBeDefined();
+
+		// domain/types/auth から import していることを確認 (multiline import 対応)
+		expect(content).toMatch(
+			/import\s+[\s\S]*?\bAuthToken\b[\s\S]*?from\s+["'].*domain\/types\/auth["']/,
+		);
+		expect(content).toMatch(
+			/import\s+[\s\S]*?\bDeviceCodeResponse\b[\s\S]*?from\s+["'].*domain\/types\/auth["']/,
+		);
+		expect(content).toMatch(
+			/import\s+[\s\S]*?\bPollResult\b[\s\S]*?from\s+["'].*domain\/types\/auth["']/,
+		);
+	});
+
+	it("shared/types/auth から AuthToken, DeviceCodeResponse, PollResult を import していないこと", () => {
+		const files = import.meta.glob("../../../adapter/chrome/identity.adapter.ts", {
+			query: "?raw",
+			eager: true,
+		}) as Record<string, { default: string }>;
+
+		expect(Object.keys(files), "adapter/chrome/identity.adapter.ts が見つかりません").toHaveLength(
+			1,
+		);
+
+		const content = Object.values(files)[0]?.default;
+		expect(content).toBeDefined();
+
+		// multiline import 文を抽出して禁止シンボルを検証
+		const sharedAuthImportPattern =
+			/import\s+(?:type\s+)?{([^}]*)}\s+from\s+["'].*shared\/types\/auth["']/g;
+		const matches = [...(content?.matchAll(sharedAuthImportPattern) ?? [])];
+
+		for (const match of matches) {
+			const importedSymbols = match[1];
+			expect(importedSymbols).not.toMatch(/\bAuthToken\b/);
+			expect(importedSymbols).not.toMatch(/\bDeviceCodeResponse\b/);
+			expect(importedSymbols).not.toMatch(/\bPollResult\b/);
+		}
+	});
+});
 
 function createMockStorage(): StoragePort & {
 	get: ReturnType<typeof vi.fn>;

--- a/src/test/adapter/github/graphql-client.test.ts
+++ b/src/test/adapter/github/graphql-client.test.ts
@@ -1,8 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { GitHubGraphQLClient } from "../../../adapter/github/graphql-client";
 import type { GitHubApiPort } from "../../../domain/ports/github-api.port";
+import type { ReviewDecision, StatusState } from "../../../domain/types/github";
 import { GitHubApiError } from "../../../shared/types/errors";
-import type { ReviewDecision, StatusState } from "../../../shared/types/github";
 
 const GRAPHQL_ENDPOINT = "https://api.github.com/graphql";
 const TEST_TOKEN = "gho_test_access_token_12345";
@@ -485,5 +485,58 @@ describe("GitHubGraphQLClient", () => {
 			expect(body.query).toContain("pageInfo");
 			expect(body.query).toContain("hasNextPage");
 		});
+	});
+});
+
+describe("graphql-client の依存方向", () => {
+	it("FetchPullRequestsResult, PullRequest, ReviewDecision, StatusState を domain/types/github から直接 import していること", () => {
+		const files = import.meta.glob("../../../adapter/github/graphql-client.ts", {
+			query: "?raw",
+			eager: true,
+		}) as Record<string, { default: string }>;
+
+		const matchedPaths = Object.keys(files);
+		expect(matchedPaths, "adapter/github/graphql-client.ts が見つかりません").toHaveLength(1);
+
+		const content = Object.values(files)[0]?.default;
+		expect(content).toBeDefined();
+
+		expect(content).toMatch(
+			/import\s+[\s\S]*?\bFetchPullRequestsResult\b[\s\S]*?from\s+["'].*domain\/types\/github["']/,
+		);
+		expect(content).toMatch(
+			/import\s+[\s\S]*?\bPullRequest\b[\s\S]*?from\s+["'].*domain\/types\/github["']/,
+		);
+		expect(content).toMatch(
+			/import\s+[\s\S]*?\bReviewDecision\b[\s\S]*?from\s+["'].*domain\/types\/github["']/,
+		);
+		expect(content).toMatch(
+			/import\s+[\s\S]*?\bStatusState\b[\s\S]*?from\s+["'].*domain\/types\/github["']/,
+		);
+	});
+
+	it("shared/types/github から FetchPullRequestsResult, PullRequest, ReviewDecision, StatusState を import していないこと", () => {
+		const files = import.meta.glob("../../../adapter/github/graphql-client.ts", {
+			query: "?raw",
+			eager: true,
+		}) as Record<string, { default: string }>;
+
+		expect(Object.keys(files), "adapter/github/graphql-client.ts が見つかりません").toHaveLength(1);
+
+		const content = Object.values(files)[0]?.default;
+		expect(content).toBeDefined();
+
+		// multiline import 文を抽出して禁止シンボルを検証
+		const sharedGithubImportPattern =
+			/import\s+(?:type\s+)?{([^}]*)}\s+from\s+["'].*shared\/types\/github["']/g;
+		const matches = [...(content?.matchAll(sharedGithubImportPattern) ?? [])];
+
+		for (const match of matches) {
+			const importedSymbols = match[1];
+			expect(importedSymbols).not.toMatch(/\bFetchPullRequestsResult\b/);
+			expect(importedSymbols).not.toMatch(/\bPullRequest\b/);
+			expect(importedSymbols).not.toMatch(/\bReviewDecision\b/);
+			expect(importedSymbols).not.toMatch(/\bStatusState\b/);
+		}
 	});
 });

--- a/src/test/domain/types/auth.test.ts
+++ b/src/test/domain/types/auth.test.ts
@@ -44,7 +44,7 @@ describe("AuthToken の型定義配置", () => {
 		expect(content).toMatch(/export\s+type\s+AuthToken\b/);
 	});
 
-	it("shared/types/auth が domain/types/auth から AuthToken を re-export していること", () => {
+	it("shared/types/auth が domain/types/auth から AuthToken を import して型ガードで使用していること", () => {
 		const sharedAuthFiles = import.meta.glob("../../../shared/types/auth.ts", {
 			query: "?raw",
 			eager: true,
@@ -55,9 +55,13 @@ describe("AuthToken の型定義配置", () => {
 		const content = Object.values(sharedAuthFiles)[0]?.default;
 		expect(content).toBeDefined();
 
-		// shared/types/auth.ts が domain/types/auth から re-export していることを検証
-		// パターン: `export type { AuthToken } from "...domain/types/auth"`
+		// shared/types/auth.ts が domain/types/auth から AuthToken を import していることを検証
 		expect(content).toMatch(
+			/import\s+type\s*\{[^}]*AuthToken[^}]*\}\s*from\s+["'].*domain\/types\/auth["']/,
+		);
+
+		// re-export はせず、型ガード (isAuthToken) で使用するのみ
+		expect(content).not.toMatch(
 			/export\s+type\s*\{[^}]*AuthToken[^}]*\}\s*from\s+["'].*domain\/types\/auth["']/,
 		);
 	});

--- a/src/test/shared/types/validators.test.ts
+++ b/src/test/shared/types/validators.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import type { AuthToken } from "../../../shared/types/auth";
+import type { AuthToken } from "../../../domain/types/auth";
 import { isAuthToken } from "../../../shared/types/auth";
 
 describe("isAuthToken", () => {

--- a/src/test/sidepanel/usecase/auth.usecase.test.ts
+++ b/src/test/sidepanel/usecase/auth.usecase.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { DeviceCodeResponse, PollResult } from "../../../domain/types/auth";
 import type { SendMessage } from "../../../shared/ports/message.port";
-import type { DeviceCodeResponse, PollResult } from "../../../shared/types/auth";
 import type { ResponseMessage } from "../../../shared/types/messages";
 import { createAuthUseCase } from "../../../sidepanel/usecase/auth.usecase";
 
@@ -187,5 +187,52 @@ describe("auth usecase", () => {
 
 			expect(result).toBe(false);
 		});
+	});
+});
+
+describe("auth.usecase の依存方向", () => {
+	it("DeviceCodeResponse, PollResult を domain/types/auth から直接 import していること", () => {
+		const files = import.meta.glob("../../../sidepanel/usecase/auth.usecase.ts", {
+			query: "?raw",
+			eager: true,
+		}) as Record<string, { default: string }>;
+
+		const matchedPaths = Object.keys(files);
+		expect(matchedPaths, "sidepanel/usecase/auth.usecase.ts が見つかりません").toHaveLength(1);
+
+		const content = Object.values(files)[0]?.default;
+		expect(content).toBeDefined();
+
+		expect(content).toMatch(
+			/import\s+[\s\S]*?\bDeviceCodeResponse\b[\s\S]*?from\s+["'].*domain\/types\/auth["']/,
+		);
+		expect(content).toMatch(
+			/import\s+[\s\S]*?\bPollResult\b[\s\S]*?from\s+["'].*domain\/types\/auth["']/,
+		);
+	});
+
+	it("shared/types/auth から DeviceCodeResponse, PollResult を import していないこと", () => {
+		const files = import.meta.glob("../../../sidepanel/usecase/auth.usecase.ts", {
+			query: "?raw",
+			eager: true,
+		}) as Record<string, { default: string }>;
+
+		expect(Object.keys(files), "sidepanel/usecase/auth.usecase.ts が見つかりません").toHaveLength(
+			1,
+		);
+
+		const content = Object.values(files)[0]?.default;
+		expect(content).toBeDefined();
+
+		// multiline import 文を抽出して禁止シンボルを検証
+		const sharedAuthImportPattern =
+			/import\s+(?:type\s+)?{([^}]*)}\s+from\s+["'].*shared\/types\/auth["']/g;
+		const matches = [...(content?.matchAll(sharedAuthImportPattern) ?? [])];
+
+		for (const match of matches) {
+			const importedSymbols = match[1];
+			expect(importedSymbols).not.toMatch(/\bDeviceCodeResponse\b/);
+			expect(importedSymbols).not.toMatch(/\bPollResult\b/);
+		}
 	});
 });


### PR DESCRIPTION
## 概要
adapter/usecase が domain の型を shared 経由で import していた依存逆流を修正し、domain 型は domain/types/ から直接 import するよう変更。不要な re-export とデッドファイルを削除し、アーキテクチャガードテストを追加。

## 変更内容
- `src/adapter/chrome/identity.adapter.ts`: `AuthToken`, `DeviceCodeResponse`, `PollResult` の import を `shared/types/auth` → `domain/types/auth` に変更
- `src/adapter/github/graphql-client.ts`: `FetchPullRequestsResult`, `PullRequest`, `ReviewDecision`, `StatusState` の import を `shared/types/github` → `domain/types/github` に変更
- `src/sidepanel/usecase/auth.usecase.ts`: `DeviceCodeResponse`, `PollResult` の import を `shared/types/auth` → `domain/types/auth` に変更
- `src/shared/types/github.ts`: 参照ゼロの re-export ファイルを削除
- `src/shared/types/auth.ts`: 不要な re-export 行を削除
- `src/shared/types/messages.ts`: `DeviceCodeResponse`, `PollResult` の import を domain から直接に変更
- `src/test/adapter/chrome/identity.adapter.test.ts`: アーキテクチャガードテスト追加 + import パス修正
- `src/test/adapter/github/graphql-client.test.ts`: アーキテクチャガードテスト追加 + import パス修正
- `src/test/sidepanel/usecase/auth.usecase.test.ts`: アーキテクチャガードテスト追加 + import パス修正
- `src/test/domain/types/auth.test.ts`: re-export 削除に伴うテスト期待値更新
- `src/test/shared/types/validators.test.ts`: `AuthToken` の import を domain から直接に変更

## 関連 Issue
- closes #65

## テスト
- [x] TypeScript 型チェック通過 (`pnpm check`)
- [x] フロントエンドテスト通過 (`pnpm test`)
- [x] Rust lint 通過 (`cargo clippy --all-targets`)
- [x] Rust テスト通過 (`cargo test`)
- [x] `/verify` で検証ループ PASS

## レビュー観点
- `shared/types/auth.ts` の `import type { AuthToken }` は `isAuthToken` 型ガードで使用するため残している。re-export ではなく import のみなので依存方向は正しい
- アーキテクチャガードテストは multiline import 対応の正規表現を使用。将来的には ESLint `no-restricted-paths` / dependency-cruiser への置き換えを検討 (#81)
- `sidepanel/usecase/` の配置は別 Issue (#80) で対応予定