### PR TITLE
fix: OAuthクレデンシャルのVITE_プレフィックスを除去しバンドル混入を防止

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,1 @@
-VITE_GITHUB_CLIENT_ID=your_github_client_id
+GITHUB_CLIENT_ID=your_github_client_id

--- a/src/shared/config/oauth.config.ts
+++ b/src/shared/config/oauth.config.ts
@@ -1,10 +1,10 @@
 import type { OAuthConfig } from "../types/auth";
 
 export function createOAuthConfig(): OAuthConfig {
-	const clientId = import.meta.env.VITE_GITHUB_CLIENT_ID;
+	const clientId = import.meta.env.GITHUB_CLIENT_ID;
 
 	if (!clientId) {
-		throw new Error("VITE_GITHUB_CLIENT_ID is not configured");
+		throw new Error("GITHUB_CLIENT_ID is not configured");
 	}
 
 	return {

--- a/src/test/background/bootstrap-auth.test.ts
+++ b/src/test/background/bootstrap-auth.test.ts
@@ -4,7 +4,7 @@ import { resetChromeMock, setupChromeMock } from "../mocks/chrome.mock";
 describe("bootstrap with auth", () => {
 	beforeEach(() => {
 		setupChromeMock();
-		vi.stubEnv("VITE_GITHUB_CLIENT_ID", "test-client-id");
+		vi.stubEnv("GITHUB_CLIENT_ID", "test-client-id");
 	});
 
 	afterEach(() => {

--- a/src/test/background/bootstrap.test.ts
+++ b/src/test/background/bootstrap.test.ts
@@ -5,7 +5,7 @@ import { resetChromeMock, setupChromeMock } from "../mocks/chrome.mock";
 describe("bootstrap", () => {
 	beforeEach(() => {
 		setupChromeMock();
-		vi.stubEnv("VITE_GITHUB_CLIENT_ID", "test-client-id");
+		vi.stubEnv("GITHUB_CLIENT_ID", "test-client-id");
 	});
 
 	afterEach(() => {

--- a/src/test/shared/config/oauth.config.test.ts
+++ b/src/test/shared/config/oauth.config.test.ts
@@ -1,17 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-/**
- * Device Flow 対応後の OAuthConfig 型。GREEN フェーズで src/shared/types/auth.ts を書き換え予定。
- * RED フェーズではテスト内にローカル定義して期待する構造を明示する。
- * GREEN フェーズで実型に差し替える際に他テストファイルの重複定義も整理する。
- */
-type DeviceFlowOAuthConfig = {
-	readonly clientId: string;
-	readonly deviceCodeEndpoint: string;
-	readonly tokenEndpoint: string;
-	readonly scopes: readonly string[];
-};
-
 describe("createOAuthConfig", () => {
 	beforeEach(() => {
 		// dynamic import のモジュールキャッシュを破棄し、各テストで再評価させる
@@ -22,21 +10,36 @@ describe("createOAuthConfig", () => {
 		vi.unstubAllEnvs();
 	});
 
-	it("should throw when VITE_GITHUB_CLIENT_ID is not set", async () => {
-		vi.stubEnv("VITE_GITHUB_CLIENT_ID", "");
+	it("should throw when GITHUB_CLIENT_ID is empty string", async () => {
+		vi.stubEnv("GITHUB_CLIENT_ID", "");
 
 		const mod = await import("../../../shared/config/oauth.config");
+		const createConfig = mod.createOAuthConfig;
+		expect(() => createConfig()).toThrow("GITHUB_CLIENT_ID is not configured");
+	});
 
-		// Device Flow 対応後は引数なしになる予定。現在のシグネチャでは引数が必要なため型キャストで呼ぶ。
-		const createConfig = mod.createOAuthConfig as unknown as () => DeviceFlowOAuthConfig;
-		expect(() => createConfig()).toThrow("VITE_GITHUB_CLIENT_ID is not configured");
+	it("should throw when GITHUB_CLIENT_ID is undefined (not set at all)", async () => {
+		// vi.stubEnv で設定しない = undefined
+
+		const mod = await import("../../../shared/config/oauth.config");
+		const createConfig = mod.createOAuthConfig;
+		expect(() => createConfig()).toThrow("GITHUB_CLIENT_ID is not configured");
+	});
+
+	it("should not use VITE_ prefixed environment variable", async () => {
+		vi.stubEnv("VITE_GITHUB_CLIENT_ID", "should-not-work");
+		// GITHUB_CLIENT_ID is not set, so it should throw even if VITE_ version exists
+
+		const mod = await import("../../../shared/config/oauth.config");
+		const createConfig = mod.createOAuthConfig;
+		expect(() => createConfig()).toThrow("GITHUB_CLIENT_ID is not configured");
 	});
 
 	it("should return OAuthConfig with deviceCodeEndpoint when client ID is set", async () => {
-		vi.stubEnv("VITE_GITHUB_CLIENT_ID", "test-client-id");
+		vi.stubEnv("GITHUB_CLIENT_ID", "test-client-id");
 
 		const mod = await import("../../../shared/config/oauth.config");
-		const createConfig = mod.createOAuthConfig as unknown as () => DeviceFlowOAuthConfig;
+		const createConfig = mod.createOAuthConfig;
 		const config = createConfig();
 
 		expect(config).toEqual({
@@ -50,40 +53,40 @@ describe("createOAuthConfig", () => {
 	// 以下の not.toHaveProperty テストは toEqual で構造的に保証されているが、
 	// Device Flow 移行で「旧プロパティが存在しないこと」を意図として明示するために残す。
 	it("should not have clientSecret property", async () => {
-		vi.stubEnv("VITE_GITHUB_CLIENT_ID", "test-client-id");
+		vi.stubEnv("GITHUB_CLIENT_ID", "test-client-id");
 
 		const mod = await import("../../../shared/config/oauth.config");
-		const createConfig = mod.createOAuthConfig as unknown as () => DeviceFlowOAuthConfig;
+		const createConfig = mod.createOAuthConfig;
 		const config = createConfig();
 
 		expect(config).not.toHaveProperty("clientSecret");
 	});
 
 	it("should not have authorizationEndpoint property", async () => {
-		vi.stubEnv("VITE_GITHUB_CLIENT_ID", "test-client-id");
+		vi.stubEnv("GITHUB_CLIENT_ID", "test-client-id");
 
 		const mod = await import("../../../shared/config/oauth.config");
-		const createConfig = mod.createOAuthConfig as unknown as () => DeviceFlowOAuthConfig;
+		const createConfig = mod.createOAuthConfig;
 		const config = createConfig();
 
 		expect(config).not.toHaveProperty("authorizationEndpoint");
 	});
 
 	it("should not have redirectUri property", async () => {
-		vi.stubEnv("VITE_GITHUB_CLIENT_ID", "test-client-id");
+		vi.stubEnv("GITHUB_CLIENT_ID", "test-client-id");
 
 		const mod = await import("../../../shared/config/oauth.config");
-		const createConfig = mod.createOAuthConfig as unknown as () => DeviceFlowOAuthConfig;
+		const createConfig = mod.createOAuthConfig;
 		const config = createConfig();
 
 		expect(config).not.toHaveProperty("redirectUri");
 	});
 
 	it("should have deviceCodeEndpoint pointing to GitHub device code URL", async () => {
-		vi.stubEnv("VITE_GITHUB_CLIENT_ID", "test-client-id");
+		vi.stubEnv("GITHUB_CLIENT_ID", "test-client-id");
 
 		const mod = await import("../../../shared/config/oauth.config");
-		const createConfig = mod.createOAuthConfig as unknown as () => DeviceFlowOAuthConfig;
+		const createConfig = mod.createOAuthConfig;
 		const config = createConfig();
 
 		expect(config.deviceCodeEndpoint).toBe("https://github.com/login/device/code");

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,6 +1,10 @@
 /// <reference types="svelte" />
 /// <reference types="vite/client" />
 
+interface ImportMetaEnv {
+	readonly GITHUB_CLIENT_ID: string;
+}
+
 declare module "*.svelte" {
 	import type { Component } from "svelte";
 	const component: Component;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,17 +3,29 @@ import { svelte } from "@sveltejs/vite-plugin-svelte";
 import { defineConfig } from "vite";
 import manifest from "./manifest.config";
 
-export default defineConfig({
-	plugins: [svelte(), crx({ manifest })],
-	build: {
-		target: "esnext",
-	},
-	optimizeDeps: {
-		exclude: ["adapter-wasm"],
-	},
-	server: {
-		fs: {
-			allow: ["src", "rust-core/crates/adapter-wasm/pkg"],
+const isViteBuild = process.argv.includes("build");
+
+export default defineConfig(() => {
+	const clientId = process.env.GITHUB_CLIENT_ID ?? "";
+	if (isViteBuild && !clientId) {
+		throw new Error("GITHUB_CLIENT_ID must be set for production builds");
+	}
+
+	return {
+		plugins: [svelte(), crx({ manifest })],
+		define: {
+			"import.meta.env.GITHUB_CLIENT_ID": JSON.stringify(clientId),
 		},
-	},
+		build: {
+			target: "esnext",
+		},
+		optimizeDeps: {
+			exclude: ["adapter-wasm"],
+		},
+		server: {
+			fs: {
+				allow: ["src", "rust-core/crates/adapter-wasm/pkg"],
+			},
+		},
+	};
 });


### PR DESCRIPTION
## 概要
OAuth環境変数 `VITE_GITHUB_CLIENT_ID` の `VITE_` プレフィックスにより、Viteがフロントエンド（Side Panel）バンドルにも値を自動公開していた問題を修正。`GITHUB_CLIENT_ID` にリネームし、`define` オプションで参照箇所のみに注入する方式に変更した。

## 変更内容
- `.env.example`: `VITE_GITHUB_CLIENT_ID` → `GITHUB_CLIENT_ID` にリネーム
- `vite.config.ts`: `define` オプションで `import.meta.env.GITHUB_CLIENT_ID` をビルド時に注入。プロダクションビルド時の環境変数未設定チェックを追加
- `src/shared/config/oauth.config.ts`: 環境変数参照とエラーメッセージを `GITHUB_CLIENT_ID` に更新
- `src/vite-env.d.ts`: `ImportMetaEnv` に `GITHUB_CLIENT_ID` の型拡張を追加
- `src/test/shared/config/oauth.config.test.ts`: 環境変数名変更、二重型キャスト除去、ネガティブテスト追加、undefined ケース追加
- `src/test/background/bootstrap.test.ts`: 環境変数名変更
- `src/test/background/bootstrap-auth.test.ts`: 環境変数名変更

## 関連 Issue
- closes #74

## テスト
- [x] TypeScript 型チェック通過 (\`pnpm check\`)
- [x] フロントエンドテスト通過 (\`pnpm test\`)
- [x] Rust lint 通過 (\`cargo clippy --all-targets\`)
- [x] Rust テスト通過 (\`cargo test\`)
- [x] \`/verify\` で検証ループ PASS

## レビュー観点
- \`define\` の \`import.meta.env.GITHUB_CLIENT_ID\` 置換がビルド時に正しく動作するか
- \`process.argv.includes("build")\` による判定が \`svelte-check\` 実行時に干渉しないか
- Side Panelバンドルに \`GITHUB_CLIENT_ID\` の値が含まれていないことの確認
- BREAKING CHANGE: \`.env\` ファイルの変数名変更が必要