### PR TITLE
refactor: OAuthConfig を shared から adapter 層に移動

### DIFF
--- a/src/adapter/chrome/identity.adapter.ts
+++ b/src/adapter/chrome/identity.adapter.ts
@@ -1,8 +1,8 @@
 import type { AuthPort } from "../../domain/ports/auth.port";
 import type { StoragePort } from "../../domain/ports/storage.port";
 import type { AuthToken, DeviceCodeResponse, PollResult } from "../../domain/types/auth";
-import type { OAuthConfig } from "../../shared/types/auth";
 import { AuthError, isAuthToken } from "../../shared/types/auth";
+import type { OAuthConfig } from "./oauth.config";
 
 const TOKEN_STORAGE_KEY = "github_auth_token";
 

--- a/src/adapter/chrome/oauth.config.ts
+++ b/src/adapter/chrome/oauth.config.ts
@@ -1,4 +1,9 @@
-import type { OAuthConfig } from "../types/auth";
+export type OAuthConfig = {
+	readonly clientId: string;
+	readonly deviceCodeEndpoint: string;
+	readonly tokenEndpoint: string;
+	readonly scopes: readonly string[];
+};
 
 export function createOAuthConfig(): OAuthConfig {
 	const clientId = import.meta.env.GITHUB_CLIENT_ID;

--- a/src/background/bootstrap.ts
+++ b/src/background/bootstrap.ts
@@ -1,9 +1,9 @@
 import { ChromeIdentityAdapter } from "../adapter/chrome/identity.adapter";
+import { createOAuthConfig } from "../adapter/chrome/oauth.config";
 import { ChromeStorageAdapter } from "../adapter/chrome/storage.adapter";
 import { GitHubGraphQLClient } from "../adapter/github/graphql-client";
 import type { AuthPort } from "../domain/ports/auth.port";
 import type { GitHubApiPort } from "../domain/ports/github-api.port";
-import { createOAuthConfig } from "../shared/config/oauth.config";
 import { GitHubApiError } from "../shared/types/errors";
 import { createMessageHandler } from "./message-handler";
 

--- a/src/shared/types/auth.ts
+++ b/src/shared/types/auth.ts
@@ -1,10 +1,3 @@
-export type OAuthConfig = {
-	readonly clientId: string;
-	readonly deviceCodeEndpoint: string;
-	readonly tokenEndpoint: string;
-	readonly scopes: readonly string[];
-};
-
 import type { AuthToken } from "../../domain/types/auth";
 
 export function isAuthToken(value: unknown): value is AuthToken {

--- a/src/test/adapter/chrome/identity.adapter.test.ts
+++ b/src/test/adapter/chrome/identity.adapter.test.ts
@@ -1,8 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ChromeIdentityAdapter } from "../../../adapter/chrome/identity.adapter";
+import type { OAuthConfig } from "../../../adapter/chrome/oauth.config";
 import type { StoragePort } from "../../../domain/ports/storage.port";
 import type { AuthToken, DeviceCodeResponse } from "../../../domain/types/auth";
-import type { OAuthConfig } from "../../../shared/types/auth";
 import { AuthError, isAuthToken } from "../../../shared/types/auth";
 import { getChromeMock, resetChromeMock, setupChromeMock } from "../../mocks/chrome.mock";
 
@@ -29,6 +29,30 @@ describe("identity.adapter の依存方向", () => {
 		expect(content).toMatch(
 			/import\s+[\s\S]*?\bPollResult\b[\s\S]*?from\s+["'].*domain\/types\/auth["']/,
 		);
+	});
+
+	it("OAuthConfig を shared/types/auth から import していないこと", () => {
+		const files = import.meta.glob("../../../adapter/chrome/identity.adapter.ts", {
+			query: "?raw",
+			eager: true,
+		}) as Record<string, { default: string }>;
+
+		expect(Object.keys(files), "adapter/chrome/identity.adapter.ts が見つかりません").toHaveLength(
+			1,
+		);
+
+		const content = Object.values(files)[0]?.default;
+		expect(content).toBeDefined();
+
+		// shared/types/auth からの import に OAuthConfig が含まれていないことを検証
+		const sharedAuthImportPattern =
+			/import\s+(?:type\s+)?{([^}]*)}\s+from\s+["'].*shared\/types\/auth["']/g;
+		const matches = [...(content?.matchAll(sharedAuthImportPattern) ?? [])];
+
+		for (const match of matches) {
+			const importedSymbols = match[1];
+			expect(importedSymbols).not.toMatch(/\bOAuthConfig\b/);
+		}
 	});
 
 	it("shared/types/auth から AuthToken, DeviceCodeResponse, PollResult を import していないこと", () => {

--- a/src/test/adapter/chrome/oauth.config.test.ts
+++ b/src/test/adapter/chrome/oauth.config.test.ts
@@ -13,7 +13,7 @@ describe("createOAuthConfig", () => {
 	it("should throw when GITHUB_CLIENT_ID is empty string", async () => {
 		vi.stubEnv("GITHUB_CLIENT_ID", "");
 
-		const mod = await import("../../../shared/config/oauth.config");
+		const mod = await import("../../../adapter/chrome/oauth.config");
 		const createConfig = mod.createOAuthConfig;
 		expect(() => createConfig()).toThrow("GITHUB_CLIENT_ID is not configured");
 	});
@@ -21,7 +21,7 @@ describe("createOAuthConfig", () => {
 	it("should throw when GITHUB_CLIENT_ID is undefined (not set at all)", async () => {
 		// vi.stubEnv で設定しない = undefined
 
-		const mod = await import("../../../shared/config/oauth.config");
+		const mod = await import("../../../adapter/chrome/oauth.config");
 		const createConfig = mod.createOAuthConfig;
 		expect(() => createConfig()).toThrow("GITHUB_CLIENT_ID is not configured");
 	});
@@ -30,7 +30,7 @@ describe("createOAuthConfig", () => {
 		vi.stubEnv("VITE_GITHUB_CLIENT_ID", "should-not-work");
 		// GITHUB_CLIENT_ID is not set, so it should throw even if VITE_ version exists
 
-		const mod = await import("../../../shared/config/oauth.config");
+		const mod = await import("../../../adapter/chrome/oauth.config");
 		const createConfig = mod.createOAuthConfig;
 		expect(() => createConfig()).toThrow("GITHUB_CLIENT_ID is not configured");
 	});
@@ -38,7 +38,7 @@ describe("createOAuthConfig", () => {
 	it("should return OAuthConfig with deviceCodeEndpoint when client ID is set", async () => {
 		vi.stubEnv("GITHUB_CLIENT_ID", "test-client-id");
 
-		const mod = await import("../../../shared/config/oauth.config");
+		const mod = await import("../../../adapter/chrome/oauth.config");
 		const createConfig = mod.createOAuthConfig;
 		const config = createConfig();
 
@@ -55,7 +55,7 @@ describe("createOAuthConfig", () => {
 	it("should not have clientSecret property", async () => {
 		vi.stubEnv("GITHUB_CLIENT_ID", "test-client-id");
 
-		const mod = await import("../../../shared/config/oauth.config");
+		const mod = await import("../../../adapter/chrome/oauth.config");
 		const createConfig = mod.createOAuthConfig;
 		const config = createConfig();
 
@@ -65,7 +65,7 @@ describe("createOAuthConfig", () => {
 	it("should not have authorizationEndpoint property", async () => {
 		vi.stubEnv("GITHUB_CLIENT_ID", "test-client-id");
 
-		const mod = await import("../../../shared/config/oauth.config");
+		const mod = await import("../../../adapter/chrome/oauth.config");
 		const createConfig = mod.createOAuthConfig;
 		const config = createConfig();
 
@@ -75,7 +75,7 @@ describe("createOAuthConfig", () => {
 	it("should not have redirectUri property", async () => {
 		vi.stubEnv("GITHUB_CLIENT_ID", "test-client-id");
 
-		const mod = await import("../../../shared/config/oauth.config");
+		const mod = await import("../../../adapter/chrome/oauth.config");
 		const createConfig = mod.createOAuthConfig;
 		const config = createConfig();
 
@@ -85,7 +85,7 @@ describe("createOAuthConfig", () => {
 	it("should have deviceCodeEndpoint pointing to GitHub device code URL", async () => {
 		vi.stubEnv("GITHUB_CLIENT_ID", "test-client-id");
 
-		const mod = await import("../../../shared/config/oauth.config");
+		const mod = await import("../../../adapter/chrome/oauth.config");
 		const createConfig = mod.createOAuthConfig;
 		const config = createConfig();
 


### PR DESCRIPTION
## 概要
OAuthConfig 型と createOAuthConfig() を `src/shared/` から `src/adapter/chrome/` に移動し、OAuth 設定をアダプタ層にカプセル化した。

## 変更内容
- `src/adapter/chrome/oauth.config.ts`: OAuthConfig 型 + createOAuthConfig() を統合した新ファイル
- `src/adapter/chrome/identity.adapter.ts`: OAuthConfig の import パスを `./oauth.config` に変更
- `src/background/bootstrap.ts`: createOAuthConfig の import パスを `../adapter/chrome/oauth.config` に変更
- `src/shared/types/auth.ts`: OAuthConfig 型を削除 (AuthError, isAuthToken は残留)
- `src/shared/config/oauth.config.ts`: ファイル削除 (adapter に移動済み)
- `src/test/adapter/chrome/oauth.config.test.ts`: テストを adapter 層に移動
- `src/test/adapter/chrome/identity.adapter.test.ts`: OAuthConfig の依存方向テストを追加

## 関連 Issue
- closes #55

## テスト
- [x] TypeScript 型チェック通過 (`pnpm check`)
- [x] フロントエンドテスト通過 (`pnpm test`) — 160 tests passed
- [x] Rust lint 通過 (`cargo clippy --all-targets`)
- [x] Rust テスト通過 (`cargo test`) — 28 tests passed
- [x] `/verify` で検証ループ PASS

## レビュー観点
- `OAuthConfig` が shared レイヤーから完全に除去されていること
- `identity.adapter.ts` の依存方向テストが退行を防いでいること
- `bootstrap.ts` (Composition Root) が adapter を直接 import するのは正しい設計パターンであること