### PR TITLE
fix: error_description のメッセージインジェクション対策

### DIFF
--- a/src/adapter/chrome/identity.adapter.ts
+++ b/src/adapter/chrome/identity.adapter.ts
@@ -106,11 +106,15 @@ export class ChromeIdentityAdapter implements AuthPort {
 					return { status: "denied" };
 				default: {
 					const raw =
-						typeof data.error_description === "string" ? data.error_description : data.error;
-					const description =
-						typeof raw === "string" && raw.length > ERROR_DESCRIPTION_MAX_LENGTH
-							? raw.slice(0, ERROR_DESCRIPTION_MAX_LENGTH)
-							: raw;
+						typeof data.error_description === "string" && data.error_description.length > 0
+							? data.error_description
+							: data.error;
+					const description = this.sanitizeOAuthErrorMessage(
+						typeof raw === "string" ? raw : String(raw),
+					);
+					if (import.meta.env.DEV) {
+						console.warn("[identity.adapter] OAuth error_description:", description);
+					}
 					throw new AuthError("token_exchange_failed", `Token exchange failed: ${description}`);
 				}
 			}
@@ -199,5 +203,17 @@ export class ChromeIdentityAdapter implements AuthPort {
 			...(typeof data.refresh_token === "string" ? { refreshToken: data.refresh_token } : {}),
 		};
 		return token;
+	}
+
+	/** HTML タグ・制御文字を除去し、長さを制限する */
+	private sanitizeOAuthErrorMessage(raw: string): string {
+		const noHtml = raw.replace(/<[^>]*>/g, "");
+		// 制御文字のうち タブ(0x09)・LF(0x0A) のみ許容する
+		// biome-ignore lint/suspicious/noControlCharactersInRegex: 制御文字除去が目的のため意図的に使用
+		const noControl = noHtml.replace(/[\x00-\x08\x0B-\x1F]/g, "");
+		const trimmed = noControl.trim();
+		return trimmed.length > ERROR_DESCRIPTION_MAX_LENGTH
+			? trimmed.slice(0, ERROR_DESCRIPTION_MAX_LENGTH)
+			: trimmed;
 	}
 }

--- a/src/test/adapter/chrome/identity.adapter.test.ts
+++ b/src/test/adapter/chrome/identity.adapter.test.ts
@@ -362,6 +362,244 @@ describe("ChromeIdentityAdapter — Device Flow", () => {
 			const savedToken = mockStorage.set.mock.calls[0][1] as Record<string, unknown>;
 			expect(savedToken.refreshToken).toBeUndefined();
 		});
+
+		describe("error_description のサニタイズ", () => {
+			/** エラーメッセージから "Token exchange failed: " プレフィックスを除いた description 部分を取得する */
+			function extractDescription(authError: AuthError): string {
+				return authError.message.replace("Token exchange failed: ", "");
+			}
+
+			it("長すぎる error_description を切り詰める (600文字 → 500文字)", async () => {
+				const longDescription = "a".repeat(600);
+				globalThis.fetch = vi.fn().mockResolvedValue({
+					ok: true,
+					json: async () => ({
+						error: "unknown_error",
+						error_description: longDescription,
+					}),
+				});
+
+				const error = await adapter
+					.pollForToken(MOCK_DEVICE_CODE_RESPONSE.deviceCode)
+					.catch((e: unknown) => e);
+
+				expect(error).toBeInstanceOf(AuthError);
+				const description = extractDescription(error as AuthError);
+				expect(description).toHaveLength(500);
+			});
+
+			it("501文字の error_description を500文字に切り詰める", async () => {
+				const description501 = "b".repeat(501);
+				globalThis.fetch = vi.fn().mockResolvedValue({
+					ok: true,
+					json: async () => ({
+						error: "unknown_error",
+						error_description: description501,
+					}),
+				});
+
+				const error = await adapter
+					.pollForToken(MOCK_DEVICE_CODE_RESPONSE.deviceCode)
+					.catch((e: unknown) => e);
+
+				expect(error).toBeInstanceOf(AuthError);
+				const description = extractDescription(error as AuthError);
+				expect(description).toHaveLength(500);
+			});
+
+			it("500文字ちょうどの error_description は切り詰められない", async () => {
+				const description500 = "c".repeat(500);
+				globalThis.fetch = vi.fn().mockResolvedValue({
+					ok: true,
+					json: async () => ({
+						error: "unknown_error",
+						error_description: description500,
+					}),
+				});
+
+				const error = await adapter
+					.pollForToken(MOCK_DEVICE_CODE_RESPONSE.deviceCode)
+					.catch((e: unknown) => e);
+
+				expect(error).toBeInstanceOf(AuthError);
+				const description = extractDescription(error as AuthError);
+				expect(description).toHaveLength(500);
+			});
+
+			it("HTML タグを除去する (<script>)", async () => {
+				globalThis.fetch = vi.fn().mockResolvedValue({
+					ok: true,
+					json: async () => ({
+						error: "unknown_error",
+						error_description: "<script>alert('xss')</script>",
+					}),
+				});
+
+				const error = await adapter
+					.pollForToken(MOCK_DEVICE_CODE_RESPONSE.deviceCode)
+					.catch((e: unknown) => e);
+
+				expect(error).toBeInstanceOf(AuthError);
+				const authError = error as AuthError;
+				expect(authError.message).not.toContain("<script>");
+				expect(authError.message).not.toContain("</script>");
+				expect(authError.message).toContain("alert('xss')");
+			});
+
+			it("HTML タグを除去する (<img onerror>)", async () => {
+				globalThis.fetch = vi.fn().mockResolvedValue({
+					ok: true,
+					json: async () => ({
+						error: "unknown_error",
+						error_description: '<img onerror="alert(1)">payload',
+					}),
+				});
+
+				const error = await adapter
+					.pollForToken(MOCK_DEVICE_CODE_RESPONSE.deviceCode)
+					.catch((e: unknown) => e);
+
+				expect(error).toBeInstanceOf(AuthError);
+				const authError = error as AuthError;
+				expect(authError.message).not.toContain("<img");
+				expect(authError.message).not.toContain("onerror");
+				expect(authError.message).toContain("payload");
+			});
+
+			it("制御文字を除去する (タブ・LF は許容、CR は除去)", async () => {
+				const descriptionWithControlChars = `error${String.fromCharCode(0)}${String.fromCharCode(1)}msg`;
+				globalThis.fetch = vi.fn().mockResolvedValue({
+					ok: true,
+					json: async () => ({
+						error: "unknown_error",
+						error_description: descriptionWithControlChars,
+					}),
+				});
+
+				const error = await adapter
+					.pollForToken(MOCK_DEVICE_CODE_RESPONSE.deviceCode)
+					.catch((e: unknown) => e);
+
+				expect(error).toBeInstanceOf(AuthError);
+				const authError = error as AuthError;
+				expect(authError.message).toContain("errormsg");
+				// 制御文字 (U+0000 ~ U+001F) のうち、タブ(0x09)・LF(0x0A) のみ許容する
+				const hasProhibitedControlChars = [...authError.message].some((ch) => {
+					const code = ch.charCodeAt(0);
+					return code <= 0x1f && code !== 0x09 && code !== 0x0a;
+				});
+				expect(hasProhibitedControlChars).toBe(false);
+			});
+
+			it("タブ・LF は保持される", async () => {
+				globalThis.fetch = vi.fn().mockResolvedValue({
+					ok: true,
+					json: async () => ({
+						error: "unknown_error",
+						error_description: "line1\tvalue\nline2",
+					}),
+				});
+
+				const error = await adapter
+					.pollForToken(MOCK_DEVICE_CODE_RESPONSE.deviceCode)
+					.catch((e: unknown) => e);
+
+				expect(error).toBeInstanceOf(AuthError);
+				const description = extractDescription(error as AuthError);
+				expect(description).toContain("\t");
+				expect(description).toContain("\n");
+				expect(description).toBe("line1\tvalue\nline2");
+			});
+
+			it("error_description なしで error フォールバック", async () => {
+				globalThis.fetch = vi.fn().mockResolvedValue({
+					ok: true,
+					json: async () => ({
+						error: "custom_err",
+					}),
+				});
+
+				const error = await adapter
+					.pollForToken(MOCK_DEVICE_CODE_RESPONSE.deviceCode)
+					.catch((e: unknown) => e);
+
+				expect(error).toBeInstanceOf(AuthError);
+				const authError = error as AuthError;
+				expect(authError.message).toContain("custom_err");
+			});
+
+			it("error_description が空文字の場合は error フィールドにフォールバック", async () => {
+				globalThis.fetch = vi.fn().mockResolvedValue({
+					ok: true,
+					json: async () => ({
+						error: "fallback_error",
+						error_description: "",
+					}),
+				});
+
+				const error = await adapter
+					.pollForToken(MOCK_DEVICE_CODE_RESPONSE.deviceCode)
+					.catch((e: unknown) => e);
+
+				expect(error).toBeInstanceOf(AuthError);
+				const authError = error as AuthError;
+				expect(authError.message).toContain("fallback_error");
+			});
+
+			it("error_description が null の場合は error フィールドにフォールバック", async () => {
+				globalThis.fetch = vi.fn().mockResolvedValue({
+					ok: true,
+					json: async () => ({
+						error: "null_desc_error",
+						error_description: null,
+					}),
+				});
+
+				const error = await adapter
+					.pollForToken(MOCK_DEVICE_CODE_RESPONSE.deviceCode)
+					.catch((e: unknown) => e);
+
+				expect(error).toBeInstanceOf(AuthError);
+				const authError = error as AuthError;
+				expect(authError.message).toContain("null_desc_error");
+			});
+
+			it("error_description が数値の場合は error フィールドにフォールバック", async () => {
+				globalThis.fetch = vi.fn().mockResolvedValue({
+					ok: true,
+					json: async () => ({
+						error: "numeric_desc_error",
+						error_description: 12345,
+					}),
+				});
+
+				const error = await adapter
+					.pollForToken(MOCK_DEVICE_CODE_RESPONSE.deviceCode)
+					.catch((e: unknown) => e);
+
+				expect(error).toBeInstanceOf(AuthError);
+				const authError = error as AuthError;
+				expect(authError.message).toContain("numeric_desc_error");
+			});
+
+			it("正常な description はそのまま通る", async () => {
+				globalThis.fetch = vi.fn().mockResolvedValue({
+					ok: true,
+					json: async () => ({
+						error: "unknown_error",
+						error_description: "Something went wrong",
+					}),
+				});
+
+				const error = await adapter
+					.pollForToken(MOCK_DEVICE_CODE_RESPONSE.deviceCode)
+					.catch((e: unknown) => e);
+
+				expect(error).toBeInstanceOf(AuthError);
+				const authError = error as AuthError;
+				expect(authError.message).toContain("Something went wrong");
+			});
+		});
 	});
 
 	describe("getToken", () => {


### PR DESCRIPTION
## 概要
OAuth エラーレスポンスの `error_description` をそのままエラーメッセージに埋め込んでいた問題を修正。HTML タグ除去・制御文字除去・長さ制限のサニタイズ処理を追加し、フィッシング・ソーシャルエンジニアリングリスクを軽減した。

## 変更内容
- `src/adapter/chrome/identity.adapter.ts`: `sanitizeOAuthErrorMessage` プライベートメソッドを追加。HTML タグ除去 (`/<[^>]*>/g`)、制御文字除去 (タブ・LF のみ許容)、長さ制限 (500文字)、トリムを実施。`pollForToken` の default ケースで空文字 `error_description` のフォールバック追加、全経路でサニタイズ適用、DEV 環境でのみサニタイズ済みログ出力
- `src/test/adapter/chrome/identity.adapter.test.ts`: `error_description のサニタイズ` describe ブロックに 12 テストケースを追加 (長さ制限 3パターン、HTML 除去 2パターン、制御文字除去、タブ・LF 保持、フォールバック 4パターン、正常系)

## 関連 Issue
- closes #56

## テスト
- [x] TypeScript 型チェック通過 (`pnpm check`)
- [x] フロントエンドテスト通過 (`pnpm test`) — 171 tests passed
- [x] Rust lint 通過 (`cargo clippy --all-targets`)
- [x] Rust テスト通過 (`cargo test`) — 28 tests passed
- [x] `/verify` で検証ループ PASS

## レビュー観点
- `sanitizeOAuthErrorMessage` の正規表現 `/<[^>]*>/g` による HTML タグ除去が十分かどうか。現在は文字列コンテキスト (throw) でのみ使用されるため innerHTML 経由の XSS リスクはないが、将来 UI に直接表示する場合は追加対策が必要
- 制御文字の許容範囲 (タブ 0x09 と LF 0x0A のみ許容、CR 0x0D は除去) が適切か
- `String(raw)` フォールバック経路も `sanitizeOAuthErrorMessage` を通す設計の妥当性