### PR TITLE
feat: API リトライ戦略・レート制限対応

### DIFF
--- a/src/adapter/github/graphql-client.ts
+++ b/src/adapter/github/graphql-client.ts
@@ -6,6 +6,9 @@ import type {
 	StatusState,
 } from "../../domain/types/github";
 import { GitHubApiError } from "../../shared/types/errors";
+import { extractRateLimitInfo } from "./rate-limit";
+import type { RetryConfig } from "./retry";
+import { withRetry } from "./retry";
 
 const GRAPHQL_ENDPOINT = "https://api.github.com/graphql";
 
@@ -103,12 +106,36 @@ query {
 }
 `;
 
+const DEFAULT_RETRY_CONFIG: RetryConfig = {
+	maxRetries: 3,
+	baseDelayMs: 1000,
+	maxDelayMs: 10000,
+};
+
+function shouldRetryError(error: unknown): boolean {
+	if (error instanceof GitHubApiError) {
+		return error.code === "server_error" || error.code === "network_error";
+	}
+	return false;
+}
+
 export class GitHubGraphQLClient implements GitHubApiPort {
-	constructor(private readonly getAccessToken: () => Promise<string>) {}
+	private readonly retryConfig: RetryConfig;
+
+	constructor(
+		private readonly getAccessToken: () => Promise<string>,
+		retryConfig?: Partial<RetryConfig>,
+	) {
+		this.retryConfig = { ...DEFAULT_RETRY_CONFIG, ...retryConfig };
+	}
 
 	async fetchPullRequests(): Promise<FetchPullRequestsResult> {
 		const token = await this.getAccessToken();
-		const response = await this.executeQuery(token);
+		const response = await withRetry(
+			() => this.executeQuery(token),
+			this.retryConfig,
+			shouldRetryError,
+		);
 		const body = await this.parseResponseBody(response);
 
 		this.checkGraphQLErrors(body);
@@ -161,11 +188,23 @@ export class GitHubGraphQLClient implements GitHubApiPort {
 		}
 
 		if (!response.ok) {
-			throw new GitHubApiError(
-				mapHttpStatusToErrorCode(response.status),
-				`GitHub API error: ${response.status} ${response.statusText}`,
-				response.status,
-			);
+			const errorCode = mapHttpStatusToErrorCode(response.status);
+			const message = `GitHub API error: ${response.status} ${response.statusText}`;
+
+			if (response.status === 429) {
+				const retryAfterStr = response.headers.get("Retry-After");
+				const retryAfter =
+					retryAfterStr !== null && Number.isFinite(Number(retryAfterStr))
+						? Number(retryAfterStr)
+						: undefined;
+				const rateLimitInfo = extractRateLimitInfo(response.headers);
+				throw new GitHubApiError(errorCode, message, response.status, undefined, {
+					retryAfter,
+					rateLimitRemaining: rateLimitInfo?.remaining,
+				});
+			}
+
+			throw new GitHubApiError(errorCode, message, response.status);
 		}
 
 		return response;

--- a/src/adapter/github/rate-limit.ts
+++ b/src/adapter/github/rate-limit.ts
@@ -1,0 +1,29 @@
+export type RateLimitInfo = {
+	readonly remaining: number;
+	readonly reset: Date;
+	readonly limit: number;
+};
+
+export function extractRateLimitInfo(headers: Headers): RateLimitInfo | null {
+	const remainingStr = headers.get("X-RateLimit-Remaining");
+	const resetStr = headers.get("X-RateLimit-Reset");
+	const limitStr = headers.get("X-RateLimit-Limit");
+
+	if (!remainingStr || !resetStr || !limitStr) {
+		return null;
+	}
+
+	const remaining = Number(remainingStr);
+	const reset = Number(resetStr);
+	const limit = Number(limitStr);
+
+	if (!Number.isFinite(remaining) || !Number.isFinite(reset) || !Number.isFinite(limit)) {
+		return null;
+	}
+
+	return {
+		remaining,
+		reset: new Date(reset * 1000),
+		limit,
+	};
+}

--- a/src/adapter/github/retry.ts
+++ b/src/adapter/github/retry.ts
@@ -1,0 +1,37 @@
+export type RetryConfig = {
+	/** 初回試行を除いたリトライ回数。maxRetries: 3 の場合、fn は最大 4 回実行される */
+	readonly maxRetries: number;
+	readonly baseDelayMs: number;
+	readonly maxDelayMs: number;
+};
+
+export type DelayFn = (ms: number) => Promise<void>;
+
+const defaultDelay: DelayFn = (ms: number) =>
+	new Promise((resolve) => {
+		const jitter = ms * Math.random() * 0.5;
+		setTimeout(resolve, ms + jitter);
+	});
+
+export async function withRetry<T>(
+	fn: () => Promise<T>,
+	config: RetryConfig,
+	shouldRetry: (error: unknown) => boolean,
+	delay: DelayFn = defaultDelay,
+): Promise<T> {
+	let attempt = 0;
+
+	for (;;) {
+		try {
+			return await fn();
+		} catch (error: unknown) {
+			if (!shouldRetry(error) || attempt >= config.maxRetries) {
+				throw error;
+			}
+
+			const delayMs = Math.min(config.baseDelayMs * 2 ** attempt, config.maxDelayMs);
+			await delay(delayMs);
+			attempt++;
+		}
+	}
+}

--- a/src/shared/types/errors.ts
+++ b/src/shared/types/errors.ts
@@ -11,13 +11,23 @@ export class GitHubApiError extends Error {
 	readonly code: GitHubApiErrorCode;
 	readonly statusCode?: number;
 	readonly details?: string;
+	readonly retryAfter?: number;
+	readonly rateLimitRemaining?: number;
 
-	constructor(code: GitHubApiErrorCode, message: string, statusCode?: number, details?: string) {
+	constructor(
+		code: GitHubApiErrorCode,
+		message: string,
+		statusCode?: number,
+		details?: string,
+		options?: { retryAfter?: number; rateLimitRemaining?: number },
+	) {
 		super(message);
 		this.name = "GitHubApiError";
 		this.code = code;
 		this.statusCode = statusCode;
 		this.details = details;
+		this.retryAfter = options?.retryAfter;
+		this.rateLimitRemaining = options?.rateLimitRemaining;
 		Object.setPrototypeOf(this, GitHubApiError.prototype);
 	}
 }

--- a/src/test/adapter/github/graphql-client.test.ts
+++ b/src/test/adapter/github/graphql-client.test.ts
@@ -334,6 +334,7 @@ describe("GitHubGraphQLClient", () => {
 				ok: false,
 				status: 429,
 				statusText: "Too Many Requests",
+				headers: new Headers(),
 			});
 
 			const error = await client.fetchPullRequests().catch((e: unknown) => e);
@@ -343,22 +344,25 @@ describe("GitHubGraphQLClient", () => {
 		});
 
 		it("should throw GitHubApiError with 'server_error' on HTTP 500", async () => {
+			const noRetryClient = new GitHubGraphQLClient(mockGetAccessToken, { maxRetries: 0 });
 			globalThis.fetch = vi.fn().mockResolvedValue({
 				ok: false,
 				status: 500,
 				statusText: "Internal Server Error",
+				headers: new Headers(),
 			});
 
-			const error = await client.fetchPullRequests().catch((e: unknown) => e);
+			const error = await noRetryClient.fetchPullRequests().catch((e: unknown) => e);
 			expect(error).toBeInstanceOf(GitHubApiError);
 			expect((error as GitHubApiError).code).toBe("server_error");
 			expect((error as GitHubApiError).statusCode).toBe(500);
 		});
 
 		it("should throw GitHubApiError with 'network_error' and generic message on fetch rejection", async () => {
+			const noRetryClient = new GitHubGraphQLClient(mockGetAccessToken, { maxRetries: 0 });
 			globalThis.fetch = vi.fn().mockRejectedValue(new TypeError("Failed to fetch"));
 
-			const error = await client.fetchPullRequests().catch((e: unknown) => e);
+			const error = await noRetryClient.fetchPullRequests().catch((e: unknown) => e);
 			expect(error).toBeInstanceOf(GitHubApiError);
 			expect((error as GitHubApiError).code).toBe("network_error");
 			expect((error as GitHubApiError).message).toBe("Network request failed");
@@ -484,6 +488,166 @@ describe("GitHubGraphQLClient", () => {
 			const body = JSON.parse(options.body as string) as { query: string };
 			expect(body.query).toContain("pageInfo");
 			expect(body.query).toContain("hasNextPage");
+		});
+	});
+
+	describe("fetchPullRequests - リトライ・レート制限", () => {
+		let retryClient: GitHubApiPort;
+
+		beforeEach(() => {
+			retryClient = new GitHubGraphQLClient(mockGetAccessToken, { baseDelayMs: 1, maxDelayMs: 1 });
+		});
+
+		it("should retry on 5xx and succeed on 4th attempt", async () => {
+			const fetchMock = vi
+				.fn()
+				.mockResolvedValueOnce({
+					ok: false,
+					status: 500,
+					statusText: "Internal Server Error",
+					headers: new Headers(),
+				})
+				.mockResolvedValueOnce({
+					ok: false,
+					status: 502,
+					statusText: "Bad Gateway",
+					headers: new Headers(),
+				})
+				.mockResolvedValueOnce({
+					ok: false,
+					status: 503,
+					statusText: "Service Unavailable",
+					headers: new Headers(),
+				})
+				.mockResolvedValueOnce({
+					ok: true,
+					json: async () => createSuccessResponse(),
+				});
+			globalThis.fetch = fetchMock;
+
+			const result = await retryClient.fetchPullRequests();
+
+			expect(result.myPrs).toEqual([]);
+			expect(result.reviewRequested).toEqual([]);
+			expect(fetchMock).toHaveBeenCalledTimes(4);
+		});
+
+		it("should throw last error after all 5xx retries exhausted", async () => {
+			const fetchMock = vi.fn().mockResolvedValue({
+				ok: false,
+				status: 500,
+				statusText: "Internal Server Error",
+				headers: new Headers(),
+			});
+			globalThis.fetch = fetchMock;
+
+			const error = await retryClient.fetchPullRequests().catch((e: unknown) => e);
+
+			expect(error).toBeInstanceOf(GitHubApiError);
+			expect((error as GitHubApiError).code).toBe("server_error");
+			expect(fetchMock).toHaveBeenCalledTimes(4);
+		});
+
+		it("should retry on network_error and succeed on 2nd attempt", async () => {
+			const fetchMock = vi
+				.fn()
+				.mockRejectedValueOnce(new TypeError("Failed to fetch"))
+				.mockResolvedValueOnce({
+					ok: true,
+					json: async () => createSuccessResponse(),
+				});
+			globalThis.fetch = fetchMock;
+
+			const result = await retryClient.fetchPullRequests();
+
+			expect(result.myPrs).toEqual([]);
+			expect(fetchMock).toHaveBeenCalledTimes(2);
+		});
+
+		it("should not retry on 401", async () => {
+			const fetchMock = vi.fn().mockResolvedValue({
+				ok: false,
+				status: 401,
+				statusText: "Unauthorized",
+				headers: new Headers(),
+			});
+			globalThis.fetch = fetchMock;
+
+			const error = await retryClient.fetchPullRequests().catch((e: unknown) => e);
+
+			expect(error).toBeInstanceOf(GitHubApiError);
+			expect((error as GitHubApiError).code).toBe("unauthorized");
+			expect(fetchMock).toHaveBeenCalledTimes(1);
+		});
+
+		it("should not retry on 403", async () => {
+			const fetchMock = vi.fn().mockResolvedValue({
+				ok: false,
+				status: 403,
+				statusText: "Forbidden",
+				headers: new Headers(),
+			});
+			globalThis.fetch = fetchMock;
+
+			const error = await retryClient.fetchPullRequests().catch((e: unknown) => e);
+
+			expect(error).toBeInstanceOf(GitHubApiError);
+			expect((error as GitHubApiError).code).toBe("forbidden");
+			expect(fetchMock).toHaveBeenCalledTimes(1);
+		});
+
+		it("should not retry on 429", async () => {
+			const fetchMock = vi.fn().mockResolvedValue({
+				ok: false,
+				status: 429,
+				statusText: "Too Many Requests",
+				headers: new Headers(),
+			});
+			globalThis.fetch = fetchMock;
+
+			const error = await retryClient.fetchPullRequests().catch((e: unknown) => e);
+
+			expect(error).toBeInstanceOf(GitHubApiError);
+			expect((error as GitHubApiError).code).toBe("rate_limited");
+			expect(fetchMock).toHaveBeenCalledTimes(1);
+		});
+
+		it("should include retryAfter in GitHubApiError when 429 response has rate limit headers", async () => {
+			const resetTimestamp = Math.floor(Date.now() / 1000) + 60;
+			globalThis.fetch = vi.fn().mockResolvedValue({
+				ok: false,
+				status: 429,
+				statusText: "Too Many Requests",
+				headers: new Headers({
+					"Retry-After": "60",
+					"X-RateLimit-Remaining": "0",
+					"X-RateLimit-Reset": String(resetTimestamp),
+					"X-RateLimit-Limit": "5000",
+				}),
+			});
+
+			const error = await retryClient.fetchPullRequests().catch((e: unknown) => e);
+
+			expect(error).toBeInstanceOf(GitHubApiError);
+			const apiError = error as GitHubApiError;
+			expect(apiError.code).toBe("rate_limited");
+			// GREEN フェーズで GitHubApiError に retryAfter, rateLimitRemaining を追加予定
+			expect(apiError).toHaveProperty("retryAfter", 60);
+			expect(apiError).toHaveProperty("rateLimitRemaining", 0);
+		});
+
+		it("should work normally when rate limit headers are absent", async () => {
+			const client = new GitHubGraphQLClient(mockGetAccessToken, { maxRetries: 0 });
+			globalThis.fetch = vi.fn().mockResolvedValue({
+				ok: true,
+				json: async () => createSuccessResponse(),
+			});
+
+			const result = await client.fetchPullRequests();
+
+			expect(result.myPrs).toEqual([]);
+			expect(result.reviewRequested).toEqual([]);
+			expect(result.hasMore).toBe(false);
 		});
 	});
 });

--- a/src/test/adapter/github/rate-limit.test.ts
+++ b/src/test/adapter/github/rate-limit.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "vitest";
+import { extractRateLimitInfo } from "../../../adapter/github/rate-limit";
+
+describe("extractRateLimitInfo", () => {
+	it("should return RateLimitInfo when all headers are present", () => {
+		const resetTimestamp = Math.floor(Date.now() / 1000) + 3600;
+		const headers = new Headers({
+			"X-RateLimit-Remaining": "4500",
+			"X-RateLimit-Reset": String(resetTimestamp),
+			"X-RateLimit-Limit": "5000",
+		});
+
+		const result = extractRateLimitInfo(headers);
+
+		expect(result).not.toBeNull();
+		expect(result?.remaining).toBe(4500);
+		expect(result?.reset).toEqual(new Date(resetTimestamp * 1000));
+		expect(result?.limit).toBe(5000);
+	});
+
+	it("should return null when X-RateLimit-Remaining is missing", () => {
+		const headers = new Headers({
+			"X-RateLimit-Reset": String(Math.floor(Date.now() / 1000) + 3600),
+			"X-RateLimit-Limit": "5000",
+		});
+
+		expect(extractRateLimitInfo(headers)).toBeNull();
+	});
+
+	it("should return null when X-RateLimit-Reset is missing", () => {
+		const headers = new Headers({
+			"X-RateLimit-Remaining": "4500",
+			"X-RateLimit-Limit": "5000",
+		});
+
+		expect(extractRateLimitInfo(headers)).toBeNull();
+	});
+
+	it("should return null when X-RateLimit-Limit is missing", () => {
+		const headers = new Headers({
+			"X-RateLimit-Remaining": "4500",
+			"X-RateLimit-Reset": String(Math.floor(Date.now() / 1000) + 3600),
+		});
+
+		expect(extractRateLimitInfo(headers)).toBeNull();
+	});
+
+	it("should return null when header value is not a valid number", () => {
+		const headers = new Headers({
+			"X-RateLimit-Remaining": "abc",
+			"X-RateLimit-Reset": String(Math.floor(Date.now() / 1000) + 3600),
+			"X-RateLimit-Limit": "5000",
+		});
+
+		expect(extractRateLimitInfo(headers)).toBeNull();
+	});
+
+	it("should return null when no headers are present", () => {
+		const headers = new Headers();
+
+		expect(extractRateLimitInfo(headers)).toBeNull();
+	});
+
+	it("should return null when X-RateLimit-Reset is non-numeric", () => {
+		const headers = new Headers({
+			"X-RateLimit-Remaining": "4500",
+			"X-RateLimit-Reset": "abc",
+			"X-RateLimit-Limit": "5000",
+		});
+
+		expect(extractRateLimitInfo(headers)).toBeNull();
+	});
+
+	it("should return null when X-RateLimit-Limit is non-numeric", () => {
+		const headers = new Headers({
+			"X-RateLimit-Remaining": "4500",
+			"X-RateLimit-Reset": String(Math.floor(Date.now() / 1000) + 3600),
+			"X-RateLimit-Limit": "abc",
+		});
+
+		expect(extractRateLimitInfo(headers)).toBeNull();
+	});
+
+	it("should parse X-RateLimit-Remaining of '0' as zero", () => {
+		const resetTimestamp = Math.floor(Date.now() / 1000) + 3600;
+		const headers = new Headers({
+			"X-RateLimit-Remaining": "0",
+			"X-RateLimit-Reset": String(resetTimestamp),
+			"X-RateLimit-Limit": "5000",
+		});
+
+		const result = extractRateLimitInfo(headers);
+
+		expect(result).not.toBeNull();
+		expect(result?.remaining).toBe(0);
+	});
+
+	it("should return null when header values are empty strings", () => {
+		const headers = new Headers({
+			"X-RateLimit-Remaining": "",
+			"X-RateLimit-Reset": "",
+			"X-RateLimit-Limit": "",
+		});
+
+		expect(extractRateLimitInfo(headers)).toBeNull();
+	});
+
+	it("should convert X-RateLimit-Reset UNIX timestamp (seconds) to Date correctly", () => {
+		const resetTimestamp = 1700000000;
+		const headers = new Headers({
+			"X-RateLimit-Remaining": "100",
+			"X-RateLimit-Reset": String(resetTimestamp),
+			"X-RateLimit-Limit": "5000",
+		});
+
+		const result = extractRateLimitInfo(headers);
+
+		expect(result).not.toBeNull();
+		expect(result?.reset).toEqual(new Date(resetTimestamp * 1000));
+		expect(result?.reset.getTime()).toBe(1700000000000);
+	});
+});

--- a/src/test/adapter/github/retry.test.ts
+++ b/src/test/adapter/github/retry.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it, vi } from "vitest";
+import { withRetry } from "../../../adapter/github/retry";
+import type { RetryConfig } from "../../../adapter/github/retry";
+
+describe("withRetry", () => {
+	const defaultConfig: RetryConfig = {
+		maxRetries: 3,
+		baseDelayMs: 1000,
+		maxDelayMs: 10000,
+	};
+
+	it("should return result without retry when first attempt succeeds", async () => {
+		const fn = vi.fn().mockResolvedValue("success");
+		const shouldRetry = vi.fn();
+		const delay = vi.fn().mockResolvedValue(undefined);
+
+		const result = await withRetry(fn, defaultConfig, shouldRetry, delay);
+
+		expect(result).toBe("success");
+		expect(fn).toHaveBeenCalledTimes(1);
+		expect(shouldRetry).not.toHaveBeenCalled();
+		expect(delay).not.toHaveBeenCalled();
+	});
+
+	it("should retry once and return result when second attempt succeeds", async () => {
+		const fn = vi
+			.fn()
+			.mockRejectedValueOnce(new Error("temporary failure"))
+			.mockResolvedValue("success");
+		const shouldRetry = vi.fn().mockReturnValue(true);
+		const delay = vi.fn().mockResolvedValue(undefined);
+
+		const result = await withRetry(fn, defaultConfig, shouldRetry, delay);
+
+		expect(result).toBe("success");
+		expect(fn).toHaveBeenCalledTimes(2);
+		expect(delay).toHaveBeenCalledTimes(1);
+	});
+
+	it("should throw last error after all retries exhausted", async () => {
+		const lastError = new Error("final failure");
+		const fn = vi
+			.fn()
+			.mockRejectedValueOnce(new Error("failure 1"))
+			.mockRejectedValueOnce(new Error("failure 2"))
+			.mockRejectedValueOnce(new Error("failure 3"))
+			.mockRejectedValueOnce(lastError);
+		const shouldRetry = vi.fn().mockReturnValue(true);
+		const delay = vi.fn().mockResolvedValue(undefined);
+
+		const error = await withRetry(fn, defaultConfig, shouldRetry, delay).catch((e: unknown) => e);
+
+		expect(error).toBe(lastError);
+		expect(fn).toHaveBeenCalledTimes(4);
+		expect(delay).toHaveBeenCalledTimes(3);
+	});
+
+	it("should throw immediately without retry when shouldRetry returns false", async () => {
+		const originalError = new Error("non-retryable");
+		const fn = vi.fn().mockRejectedValue(originalError);
+		const shouldRetry = vi.fn().mockReturnValue(false);
+		const delay = vi.fn().mockResolvedValue(undefined);
+
+		const error = await withRetry(fn, defaultConfig, shouldRetry, delay).catch((e: unknown) => e);
+
+		expect(error).toBe(originalError);
+		expect(fn).toHaveBeenCalledTimes(1);
+		expect(shouldRetry).toHaveBeenCalledWith(originalError);
+		expect(delay).not.toHaveBeenCalled();
+	});
+
+	it("should apply exponential backoff delays", async () => {
+		const config: RetryConfig = {
+			maxRetries: 3,
+			baseDelayMs: 1000,
+			maxDelayMs: 100000,
+		};
+		const fn = vi
+			.fn()
+			.mockRejectedValueOnce(new Error("fail 1"))
+			.mockRejectedValueOnce(new Error("fail 2"))
+			.mockRejectedValueOnce(new Error("fail 3"))
+			.mockResolvedValue("success");
+		const shouldRetry = vi.fn().mockReturnValue(true);
+		const delay = vi.fn().mockResolvedValue(undefined);
+
+		await withRetry(fn, config, shouldRetry, delay);
+
+		// exponential backoff: min(baseDelayMs * 2^attempt, maxDelayMs)
+		// attempt 0: min(1000 * 2^0, 100000) = 1000
+		// attempt 1: min(1000 * 2^1, 100000) = 2000
+		// attempt 2: min(1000 * 2^2, 100000) = 4000
+		expect(delay).toHaveBeenCalledTimes(3);
+		expect(delay).toHaveBeenNthCalledWith(1, 1000);
+		expect(delay).toHaveBeenNthCalledWith(2, 2000);
+		expect(delay).toHaveBeenNthCalledWith(3, 4000);
+	});
+
+	it("should cap delay at maxDelayMs", async () => {
+		const config: RetryConfig = {
+			maxRetries: 3,
+			baseDelayMs: 1000,
+			maxDelayMs: 1500,
+		};
+		const fn = vi
+			.fn()
+			.mockRejectedValueOnce(new Error("fail 1"))
+			.mockRejectedValueOnce(new Error("fail 2"))
+			.mockRejectedValueOnce(new Error("fail 3"))
+			.mockResolvedValue("success");
+		const shouldRetry = vi.fn().mockReturnValue(true);
+		const delay = vi.fn().mockResolvedValue(undefined);
+
+		await withRetry(fn, config, shouldRetry, delay);
+
+		expect(delay).toHaveBeenCalledTimes(3);
+		expect(delay).toHaveBeenNthCalledWith(1, 1000);
+		expect(delay).toHaveBeenNthCalledWith(2, 1500);
+		expect(delay).toHaveBeenNthCalledWith(3, 1500);
+	});
+
+	it("should not retry when maxRetries is 0", async () => {
+		const config: RetryConfig = {
+			maxRetries: 0,
+			baseDelayMs: 1000,
+			maxDelayMs: 10000,
+		};
+		const fn = vi.fn().mockResolvedValue("immediate");
+		const shouldRetry = vi.fn();
+		const delay = vi.fn().mockResolvedValue(undefined);
+
+		const result = await withRetry(fn, config, shouldRetry, delay);
+
+		expect(result).toBe("immediate");
+		expect(fn).toHaveBeenCalledTimes(1);
+		expect(delay).not.toHaveBeenCalled();
+	});
+
+	it("should throw on first failure when maxRetries is 0", async () => {
+		const config: RetryConfig = {
+			maxRetries: 0,
+			baseDelayMs: 1000,
+			maxDelayMs: 10000,
+		};
+		const originalError = new Error("single failure");
+		const fn = vi.fn().mockRejectedValue(originalError);
+		const shouldRetry = vi.fn().mockReturnValue(true);
+		const delay = vi.fn().mockResolvedValue(undefined);
+
+		const error = await withRetry(fn, config, shouldRetry, delay).catch((e: unknown) => e);
+
+		expect(error).toBe(originalError);
+		expect(fn).toHaveBeenCalledTimes(1);
+		expect(delay).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
## 概要

GitHub GraphQL API への 5xx/network_error に対する exponential backoff + jitter 付きリトライと、429 レスポンスのレート制限ヘッダー情報を GitHubApiError に付与する機能を追加。

## 変更内容

- `src/adapter/github/retry.ts`: exponential backoff + jitter 付きリトライユーティリティ (DelayFn の DI でテスタブル)
- `src/adapter/github/rate-limit.ts`: レスポンスヘッダーからレート制限情報 (Remaining/Reset/Limit) を抽出するユーティリティ
- `src/adapter/github/graphql-client.ts`: fetchPullRequests を withRetry でラップ。429 レスポンス時に retryAfter/rateLimitRemaining を GitHubApiError に付与
- `src/shared/types/errors.ts`: GitHubApiError に retryAfter, rateLimitRemaining フィールドを追加 (オプショナル、後方互換)
- `src/test/adapter/github/retry.test.ts`: リトライユーティリティの 8 テストケース
- `src/test/adapter/github/rate-limit.test.ts`: レート制限ヘッダー抽出の 11 テストケース
- `src/test/adapter/github/graphql-client.test.ts`: リトライ・レート制限統合の 8 テストケース追加 + 既存テスト修正

## 関連 Issue

- closes #38

## テスト

- [x] TypeScript 型チェック通過 (`pnpm check`)
- [x] フロントエンドテスト通過 (`pnpm test`) — 186 tests passed
- [ ] Rust lint 通過 (`cargo clippy --all-targets`) — Rust 変更なし
- [ ] Rust テスト通過 (`cargo test`) — Rust 変更なし
- [x] `/verify` で検証ループ PASS

## レビュー観点

- `shouldRetryError` が `server_error` と `network_error` のみをリトライ対象とし、`rate_limited` (429) をリトライしない設計判断の妥当性。429 の Retry-After ベースリトライは Issue #92 で別途対応予定
- `GitHubApiError` コンストラクタの第5引数 `options` パターンの後方互換性
- `defaultDelay` 内の jitter (0〜50%) が thundering herd 緩和に十分か
- テスト内の `retryClient` が `baseDelayMs: 1, maxDelayMs: 1` で統合テストの実行速度を確保している点