### PR TITLE
feat: トークン有効期限バッファ追加 & リフレッシュフロー実装

### DIFF
--- a/src/adapter/chrome/identity.adapter.ts
+++ b/src/adapter/chrome/identity.adapter.ts
@@ -6,6 +6,9 @@ import { AuthError, isAuthToken } from "../../shared/types/auth";
 
 const TOKEN_STORAGE_KEY = "github_auth_token";
 
+/** 有効期限の5分前にトークンを期限切れと見なし、早期リフレッシュを促す */
+const TOKEN_EXPIRY_BUFFER_MS = 5 * 60 * 1000;
+
 /** device_code の最小長。GitHub は40文字 hex を返す */
 const DEVICE_CODE_MIN_LENGTH = 8;
 const DEVICE_CODE_MAX_LENGTH = 256;
@@ -15,6 +18,8 @@ const ERROR_DESCRIPTION_MAX_LENGTH = 500;
 
 export class ChromeIdentityAdapter implements AuthPort {
 	private cachedAuthenticated: boolean | null = null;
+	private cachedExpiresAt: number | undefined = undefined;
+	private refreshPromise: Promise<AuthToken | null> | null = null;
 
 	constructor(
 		private readonly storage: StoragePort,
@@ -24,7 +29,13 @@ export class ChromeIdentityAdapter implements AuthPort {
 			if (areaName !== "local") return;
 			if (TOKEN_STORAGE_KEY in changes) {
 				const change = changes[TOKEN_STORAGE_KEY];
-				this.cachedAuthenticated = change.newValue !== undefined;
+				if (change.newValue !== undefined) {
+					this.cachedAuthenticated = true;
+					this.cachedExpiresAt = undefined; // 次回 isAuthenticated() で再取得
+				} else {
+					this.cachedAuthenticated = false;
+					this.cachedExpiresAt = undefined;
+				}
 			}
 		});
 	}
@@ -44,6 +55,7 @@ export class ChromeIdentityAdapter implements AuthPort {
 					Accept: "application/json",
 				},
 				body: body.toString(),
+				redirect: "error",
 			});
 		} catch (error: unknown) {
 			const message = error instanceof Error ? error.message : "Unknown error";
@@ -80,6 +92,7 @@ export class ChromeIdentityAdapter implements AuthPort {
 					device_code: deviceCode,
 					grant_type: "urn:ietf:params:oauth:grant-type:device_code",
 				}).toString(),
+				redirect: "error",
 			});
 		} catch (error: unknown) {
 			const message = error instanceof Error ? error.message : "Unknown error";
@@ -119,33 +132,112 @@ export class ChromeIdentityAdapter implements AuthPort {
 		const token = this.validateTokenData(data);
 		await this.storage.set(TOKEN_STORAGE_KEY, token);
 		this.cachedAuthenticated = true;
+		this.cachedExpiresAt = token.expiresAt;
 		return { status: "success", token };
 	}
 
 	async getToken(): Promise<AuthToken | null> {
-		return this.storage.get<AuthToken>(TOKEN_STORAGE_KEY, isAuthToken);
+		const token = await this.storage.get<AuthToken>(TOKEN_STORAGE_KEY, isAuthToken);
+		if (token === null) return null;
+
+		if (this.isTokenExpiredWithBuffer(token.expiresAt)) {
+			if (!this.refreshPromise) {
+				this.refreshPromise = this.performRefresh(token).finally(() => {
+					this.refreshPromise = null;
+				});
+			}
+			const refreshed = await this.refreshPromise;
+			if (refreshed !== null) return refreshed;
+			await this.clearToken();
+			return null;
+		}
+
+		return token;
 	}
 
 	async clearToken(): Promise<void> {
 		await this.storage.remove(TOKEN_STORAGE_KEY);
 		this.cachedAuthenticated = false;
+		this.cachedExpiresAt = undefined;
 	}
 
 	async isAuthenticated(): Promise<boolean> {
+		// バッファ圏内に入ったキャッシュ済みトークンは期限切れと見なす
+		if (this.cachedAuthenticated === true && this.cachedExpiresAt !== undefined) {
+			if (Date.now() >= this.cachedExpiresAt - TOKEN_EXPIRY_BUFFER_MS) {
+				return false; // cachedAuthenticated は変更しない — 次回呼び出しでも再判定
+			}
+			return true;
+		}
+
 		if (this.cachedAuthenticated !== null) {
 			return this.cachedAuthenticated;
 		}
-		const token = await this.getToken();
+
+		const token = await this.storage.get<AuthToken>(TOKEN_STORAGE_KEY, isAuthToken);
 		if (token === null) {
 			this.cachedAuthenticated = false;
 			return false;
 		}
-		if (token.expiresAt !== undefined && Date.now() >= token.expiresAt) {
+		if (this.isTokenExpiredWithBuffer(token.expiresAt)) {
 			this.cachedAuthenticated = false;
 			return false;
 		}
 		this.cachedAuthenticated = true;
+		this.cachedExpiresAt = token.expiresAt;
 		return true;
+	}
+
+	async refreshAccessToken(): Promise<AuthToken | null> {
+		const token = await this.storage.get<AuthToken>(TOKEN_STORAGE_KEY, isAuthToken);
+		if (!token?.refreshToken) return null;
+		if (!this.refreshPromise) {
+			this.refreshPromise = this.performRefresh(token).finally(() => {
+				this.refreshPromise = null;
+			});
+		}
+		return this.refreshPromise;
+	}
+
+	private async performRefresh(token: AuthToken): Promise<AuthToken | null> {
+		if (!token.refreshToken) return null;
+		try {
+			const body = new URLSearchParams({
+				grant_type: "refresh_token",
+				client_id: this.config.clientId,
+				refresh_token: token.refreshToken,
+			});
+
+			const response = await fetch(this.config.tokenEndpoint, {
+				method: "POST",
+				headers: {
+					"Content-Type": "application/x-www-form-urlencoded",
+					Accept: "application/json",
+				},
+				body: body.toString(),
+				redirect: "error",
+			});
+
+			// HTTP エラー時は原因によらず null を返す。
+			// 呼び出し元の getToken() が clearToken() でフォールバックし再認証を促す。
+			// 将来的にリトライ戦略が必要な場合は、ここで 429/500 を区別する。
+			if (!response.ok) return null;
+
+			const data = (await response.json()) as Record<string, unknown>;
+			const newToken = this.validateTokenData(data);
+			await this.storage.set(TOKEN_STORAGE_KEY, newToken);
+			this.cachedAuthenticated = true;
+			this.cachedExpiresAt = newToken.expiresAt;
+			return newToken;
+		} catch {
+			return null;
+		}
+	}
+
+	/** expiresAt がありバッファ圏内なら期限切れと判定する */
+	private isTokenExpiredWithBuffer(expiresAt: number | undefined): boolean {
+		if (expiresAt === undefined) return false;
+		return Date.now() >= expiresAt - TOKEN_EXPIRY_BUFFER_MS;
 	}
 
 	private validateDeviceCodeData(data: Record<string, unknown>): DeviceCodeResponse {

--- a/src/background/bootstrap.ts
+++ b/src/background/bootstrap.ts
@@ -22,7 +22,7 @@ export function initializeApp(): AppServices {
 	const githubApi = new GitHubGraphQLClient(async () => {
 		const token = await auth.getToken();
 		if (!token) {
-			throw new GitHubApiError("unauthorized", "Not authenticated");
+			throw new GitHubApiError("unauthorized", "Not authenticated. Token may have expired.");
 		}
 		return token.accessToken;
 	});

--- a/src/domain/ports/auth.port.ts
+++ b/src/domain/ports/auth.port.ts
@@ -7,4 +7,6 @@ export interface AuthPort {
 	requestDeviceCode(): Promise<DeviceCodeResponse>;
 	/** 1回分のトークン取得試行。Service Worker 30秒制限のためループせず即座に結果を返す */
 	pollForToken(deviceCode: string): Promise<PollResult>;
+	/** refresh_token を使ってアクセストークンを更新する。refresh_token がない場合は null を返す */
+	refreshAccessToken(): Promise<AuthToken | null>;
 }

--- a/src/test/adapter/chrome/identity.adapter.test.ts
+++ b/src/test/adapter/chrome/identity.adapter.test.ts
@@ -623,3 +623,385 @@ describe("ChromeIdentityAdapter — Device Flow", () => {
 		});
 	});
 });
+
+// ============================================================
+// Issue #57: トークン有効期限バッファ & リフレッシュフロー
+// ============================================================
+
+const TOKEN_EXPIRY_BUFFER_MS = 5 * 60 * 1000;
+
+const MOCK_TOKEN_WITH_REFRESH: AuthToken = {
+	accessToken: "gho_test_access_token",
+	tokenType: "bearer",
+	scope: "repo",
+	refreshToken: "ghr_test_refresh_token",
+};
+
+describe("ChromeIdentityAdapter — Expiry Buffer (Issue #57)", () => {
+	let adapter: ChromeIdentityAdapter;
+	let mockStorage: ReturnType<typeof createMockStorage>;
+	let originalFetch: typeof globalThis.fetch;
+
+	beforeEach(() => {
+		setupChromeMock();
+		mockStorage = createMockStorage();
+		mockStorage.set.mockResolvedValue(undefined);
+		mockStorage.remove.mockResolvedValue(undefined);
+		adapter = new ChromeIdentityAdapter(mockStorage, TEST_CONFIG);
+		originalFetch = globalThis.fetch;
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+		resetChromeMock();
+		globalThis.fetch = originalFetch;
+	});
+
+	describe("isAuthenticated with buffer", () => {
+		it("should return false when expiresAt is within buffer (now + 4min)", async () => {
+			vi.useFakeTimers();
+			vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+
+			const now = Date.now();
+			mockStorage.get.mockResolvedValue({
+				...MOCK_TOKEN,
+				expiresAt: now + 4 * 60 * 1000, // 4 minutes from now — within 5min buffer
+			});
+
+			const result = await adapter.isAuthenticated();
+
+			expect(result).toBe(false);
+		});
+
+		it("should return true when expiresAt is outside buffer (now + 6min)", async () => {
+			vi.useFakeTimers();
+			vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+
+			const now = Date.now();
+			mockStorage.get.mockResolvedValue({
+				...MOCK_TOKEN,
+				expiresAt: now + 6 * 60 * 1000, // 6 minutes from now — outside 5min buffer
+			});
+
+			const result = await adapter.isAuthenticated();
+
+			expect(result).toBe(true);
+		});
+
+		it("should return false when expiresAt is exactly at buffer boundary (now + 5min)", async () => {
+			vi.useFakeTimers();
+			vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+
+			const now = Date.now();
+			mockStorage.get.mockResolvedValue({
+				...MOCK_TOKEN,
+				expiresAt: now + TOKEN_EXPIRY_BUFFER_MS, // exactly 5 minutes — boundary => false (>= means expired)
+			});
+
+			const result = await adapter.isAuthenticated();
+
+			expect(result).toBe(false);
+		});
+
+		it("should return true for non-expiring token (no expiresAt) regardless of buffer", async () => {
+			mockStorage.get.mockResolvedValue({
+				...MOCK_TOKEN,
+				// expiresAt is undefined
+			});
+
+			const result = await adapter.isAuthenticated();
+
+			expect(result).toBe(true);
+		});
+	});
+
+	describe("cache with buffer — time progression", () => {
+		it("should return false when cached token enters buffer zone after time passes", async () => {
+			vi.useFakeTimers();
+			vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+
+			const now = Date.now();
+			const expiresAt = now + 6 * 60 * 1000; // 6 minutes — outside buffer initially
+
+			mockStorage.get.mockResolvedValue({
+				...MOCK_TOKEN,
+				expiresAt,
+			});
+
+			// First call: outside buffer → true
+			const first = await adapter.isAuthenticated();
+			expect(first).toBe(true);
+
+			// Advance time by 2 minutes → expiresAt is now 4min away → inside buffer
+			vi.advanceTimersByTime(2 * 60 * 1000);
+
+			// Same adapter instance — cache should re-evaluate based on time
+			const second = await adapter.isAuthenticated();
+			expect(second).toBe(false);
+		});
+	});
+});
+
+describe("ChromeIdentityAdapter — getToken with expiry check (Issue #57)", () => {
+	let adapter: ChromeIdentityAdapter;
+	let mockStorage: ReturnType<typeof createMockStorage>;
+	let originalFetch: typeof globalThis.fetch;
+
+	beforeEach(() => {
+		setupChromeMock();
+		mockStorage = createMockStorage();
+		mockStorage.set.mockResolvedValue(undefined);
+		mockStorage.remove.mockResolvedValue(undefined);
+		adapter = new ChromeIdentityAdapter(mockStorage, TEST_CONFIG);
+		originalFetch = globalThis.fetch;
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+		resetChromeMock();
+		globalThis.fetch = originalFetch;
+	});
+
+	it("should refresh and return new token when token is expired and refreshToken exists", async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+
+		const now = Date.now();
+		const expiredToken: AuthToken = {
+			...MOCK_TOKEN_WITH_REFRESH,
+			expiresAt: now - 1000, // expired
+		};
+		mockStorage.get.mockResolvedValue(expiredToken);
+
+		// Mock successful refresh
+		globalThis.fetch = vi.fn().mockResolvedValue({
+			ok: true,
+			json: async () => ({
+				access_token: "gho_new_access_token",
+				token_type: "bearer",
+				scope: "repo",
+				expires_in: 3600,
+				refresh_token: "ghr_new_refresh_token",
+			}),
+		});
+
+		const result = await adapter.getToken();
+
+		expect(result).not.toBeNull();
+		expect(result?.accessToken).toBe("gho_new_access_token");
+		expect(result?.refreshToken).toBe("ghr_new_refresh_token");
+	});
+
+	it("should return null and clear token when expired and refresh fails", async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+
+		const now = Date.now();
+		const expiredToken: AuthToken = {
+			...MOCK_TOKEN_WITH_REFRESH,
+			expiresAt: now - 1000,
+		};
+		mockStorage.get.mockResolvedValue(expiredToken);
+
+		// Mock failed refresh
+		globalThis.fetch = vi.fn().mockResolvedValue({
+			ok: false,
+			status: 400,
+		});
+
+		const result = await adapter.getToken();
+
+		expect(result).toBeNull();
+		expect(mockStorage.remove).toHaveBeenCalledWith("github_auth_token");
+	});
+
+	it("should return null and clear token when expired and no refreshToken", async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+
+		const now = Date.now();
+		const expiredTokenNoRefresh: AuthToken = {
+			accessToken: "gho_test_access_token",
+			tokenType: "bearer",
+			scope: "repo",
+			expiresAt: now - 1000,
+			// no refreshToken
+		};
+		mockStorage.get.mockResolvedValue(expiredTokenNoRefresh);
+
+		const result = await adapter.getToken();
+
+		expect(result).toBeNull();
+		expect(mockStorage.remove).toHaveBeenCalledWith("github_auth_token");
+	});
+
+	it("should return token as-is when not expired", async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+
+		const now = Date.now();
+		const validToken: AuthToken = {
+			...MOCK_TOKEN,
+			expiresAt: now + 3600 * 1000, // 1 hour from now
+		};
+		mockStorage.get.mockResolvedValue(validToken);
+
+		const result = await adapter.getToken();
+
+		expect(result).toEqual(validToken);
+	});
+
+	it("should refresh when token is within buffer zone (expiresAt = now + 4min)", async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+
+		const now = Date.now();
+		const bufferZoneToken: AuthToken = {
+			...MOCK_TOKEN_WITH_REFRESH,
+			expiresAt: now + 4 * 60 * 1000, // 4 min from now — within 5min buffer
+		};
+		mockStorage.get.mockResolvedValue(bufferZoneToken);
+
+		globalThis.fetch = vi.fn().mockResolvedValue({
+			ok: true,
+			json: async () => ({
+				access_token: "gho_refreshed_buffer",
+				token_type: "bearer",
+				scope: "repo",
+				expires_in: 3600,
+				refresh_token: "ghr_new_buffer",
+			}),
+		});
+
+		const result = await adapter.getToken();
+
+		expect(result).not.toBeNull();
+		expect(result?.accessToken).toBe("gho_refreshed_buffer");
+	});
+
+	it("should return token as-is when expiresAt is undefined", async () => {
+		mockStorage.get.mockResolvedValue(MOCK_TOKEN); // no expiresAt
+
+		const result = await adapter.getToken();
+
+		expect(result).toEqual(MOCK_TOKEN);
+	});
+});
+
+describe("ChromeIdentityAdapter — refreshAccessToken (Issue #57)", () => {
+	let adapter: ChromeIdentityAdapter;
+	let mockStorage: ReturnType<typeof createMockStorage>;
+	let originalFetch: typeof globalThis.fetch;
+
+	beforeEach(() => {
+		setupChromeMock();
+		mockStorage = createMockStorage();
+		mockStorage.set.mockResolvedValue(undefined);
+		mockStorage.remove.mockResolvedValue(undefined);
+		adapter = new ChromeIdentityAdapter(mockStorage, TEST_CONFIG);
+		originalFetch = globalThis.fetch;
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+		resetChromeMock();
+		globalThis.fetch = originalFetch;
+	});
+
+	it("should POST to tokenEndpoint with grant_type=refresh_token and correct parameters", async () => {
+		globalThis.fetch = vi.fn().mockResolvedValue({
+			ok: true,
+			json: async () => ({
+				access_token: "gho_refreshed",
+				token_type: "bearer",
+				scope: "repo",
+				expires_in: 3600,
+				refresh_token: "ghr_new",
+			}),
+		});
+
+		// Store a token with refreshToken so the adapter has it
+		mockStorage.get.mockResolvedValue(MOCK_TOKEN_WITH_REFRESH);
+
+		await adapter.refreshAccessToken();
+
+		const fetchMock = globalThis.fetch as ReturnType<typeof vi.fn>;
+		expect(fetchMock).toHaveBeenCalledWith(
+			TEST_CONFIG.tokenEndpoint,
+			expect.objectContaining({ method: "POST" }),
+		);
+		const [, options] = fetchMock.mock.calls[0] as [string, RequestInit];
+		const body = options.body as string;
+		expect(body).toContain("grant_type=refresh_token");
+		expect(body).toContain("client_id=test-client-id");
+		expect(body).toContain(
+			`refresh_token=${encodeURIComponent(MOCK_TOKEN_WITH_REFRESH.refreshToken as string)}`,
+		);
+	});
+
+	it("should save new token to storage and return it on success", async () => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+
+		globalThis.fetch = vi.fn().mockResolvedValue({
+			ok: true,
+			json: async () => ({
+				access_token: "gho_refreshed",
+				token_type: "bearer",
+				scope: "repo",
+				expires_in: 7200,
+				refresh_token: "ghr_new",
+			}),
+		});
+
+		mockStorage.get.mockResolvedValue(MOCK_TOKEN_WITH_REFRESH);
+
+		const result = await adapter.refreshAccessToken();
+
+		expect(result).not.toBeNull();
+		expect(result?.accessToken).toBe("gho_refreshed");
+		expect(result?.refreshToken).toBe("ghr_new");
+		expect(mockStorage.set).toHaveBeenCalledWith(
+			"github_auth_token",
+			expect.objectContaining({
+				accessToken: "gho_refreshed",
+				expiresAt: Date.now() + 7200 * 1000,
+			}),
+		);
+	});
+
+	it("should return null when refresh HTTP response is not ok", async () => {
+		globalThis.fetch = vi.fn().mockResolvedValue({
+			ok: false,
+			status: 401,
+		});
+
+		mockStorage.get.mockResolvedValue(MOCK_TOKEN_WITH_REFRESH);
+
+		const result = await adapter.refreshAccessToken();
+
+		expect(result).toBeNull();
+	});
+
+	it("should return null when fetch rejects with network error", async () => {
+		globalThis.fetch = vi.fn().mockRejectedValue(new TypeError("Network error"));
+
+		mockStorage.get.mockResolvedValue(MOCK_TOKEN_WITH_REFRESH);
+
+		const result = await adapter.refreshAccessToken();
+
+		expect(result).toBeNull();
+	});
+
+	it("should return null when no refreshToken exists on stored token", async () => {
+		const fetchMock = vi.fn();
+		globalThis.fetch = fetchMock;
+
+		mockStorage.get.mockResolvedValue(MOCK_TOKEN); // no refreshToken
+
+		const result = await adapter.refreshAccessToken();
+
+		expect(result).toBeNull();
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+});

--- a/src/test/background/message-handler.test.ts
+++ b/src/test/background/message-handler.test.ts
@@ -14,6 +14,7 @@ function createMockAuth(): {
 		isAuthenticated: vi.fn(),
 		requestDeviceCode: vi.fn(),
 		pollForToken: vi.fn(),
+		refreshAccessToken: vi.fn(),
 	};
 }
 


### PR DESCRIPTION
## 概要
トークン有効期限の5分前に早期失効バッファを設け、期限切れ直前の API コール 401 を防止する。refresh_token がある場合は自動リフレッシュを試行し、ない場合は期限切れトークンをクリアして再認証を促す。

## 変更内容
- `src/adapter/chrome/identity.adapter.ts`: TOKEN_EXPIRY_BUFFER_MS 定数追加、isAuthenticated() にバッファ付き判定、getToken() に期限チェック+自動リフレッシュ、refreshAccessToken()/performRefresh() 実装、refreshPromise dedupe パターン、全 fetch に redirect: "error" 追加、onChanged で cachedExpiresAt 同期
- `src/domain/ports/auth.port.ts`: AuthPort に refreshAccessToken() メソッド追加
- `src/background/bootstrap.ts`: getToken() null 時のエラーメッセージ改善
- `src/test/adapter/chrome/identity.adapter.test.ts`: バッファ・リフレッシュ・getToken 期限チェックのテスト12件追加
- `src/test/background/message-handler.test.ts`: AuthPort モックに refreshAccessToken 追加

## 関連 Issue
- closes #57

## テスト
- [x] TypeScript 型チェック通過 (`pnpm check`)
- [x] フロントエンドテスト通過 (`pnpm test`) — 175/175 PASS
- [ ] Rust lint 通過 (`cargo clippy --all-targets`) — Rust 変更なし
- [ ] Rust テスト通過 (`cargo test`) — Rust 変更なし
- [x] `/verify` で検証ループ PASS

## レビュー観点
1. **refreshPromise dedupe パターン**: getToken() と refreshAccessToken() の両方で共有している。並行呼び出し時に同一 Promise を返す設計が正しいか
2. **isAuthenticated() のバッファ判定**: cachedAuthenticated を false にセットせず return false のみで対応。リフレッシュ成功後にキャッシュが不整合にならないか
3. **performRefresh() の fetch オプション**: redirect: "error" の追加が既存の requestDeviceCode/pollForToken にも適用されている点
4. **GitHub Device Flow の refresh_token**: シークレットなしでのリフレッシュが Device Flow の仕様通りか (調査では不要と確認済み)