### PR TITLE
feat: From<&PullRequest> for PrItemDto を実装

### DIFF
--- a/rust-core/crates/domain/src/dto.rs
+++ b/rust-core/crates/domain/src/dto.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 use tsify_next::Tsify;
 
+use crate::entity::PullRequest;
 use crate::status::{ApprovalStatus, CiStatus};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Tsify)]
@@ -22,6 +23,26 @@ pub struct PrItemDto {
     pub created_at: String,
     /// ISO 8601 形式の文字列。chrono 不使用で WASM バイナリサイズを削減。
     pub updated_at: String,
+}
+
+impl From<&PullRequest> for PrItemDto {
+    fn from(pr: &PullRequest) -> Self {
+        Self {
+            id: pr.id().to_string(),
+            number: pr.number(),
+            title: pr.title().to_string(),
+            author: pr.author().to_string(),
+            url: pr.url().to_string(),
+            repository: pr.repository().to_string(),
+            is_draft: pr.is_draft(),
+            approval_status: pr.approval_status(),
+            ci_status: pr.ci_status(),
+            additions: pr.additions(),
+            deletions: pr.deletions(),
+            created_at: pr.created_at().to_string(),
+            updated_at: pr.updated_at().to_string(),
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Tsify)]
@@ -124,5 +145,81 @@ mod tests {
         let original = make_pr_item();
         let cloned = original.clone();
         assert_eq!(original, cloned);
+    }
+
+    #[test]
+    fn from_pull_request_produces_matching_dto() {
+        use crate::entity::PullRequest;
+
+        let pr = PullRequest::new(
+            "PR_456".to_string(),
+            99,
+            "Implement feature Y".to_string(),
+            "monalisa".to_string(),
+            "https://github.com/org/repo/pull/99".to_string(),
+            "org/repo".to_string(),
+            true,
+            ApprovalStatus::ChangesRequested,
+            CiStatus::Failed,
+            250,
+            80,
+            "2026-03-01T12:00:00Z".to_string(),
+            "2026-03-15T18:30:00Z".to_string(),
+        )
+        .expect("test PR should be valid");
+
+        let dto = PrItemDto::from(&pr);
+
+        assert_eq!(dto.id, "PR_456");
+        assert_eq!(dto.number, 99);
+        assert_eq!(dto.title, "Implement feature Y");
+        assert_eq!(dto.author, "monalisa");
+        assert_eq!(dto.url, "https://github.com/org/repo/pull/99");
+        assert_eq!(dto.repository, "org/repo");
+        assert!(dto.is_draft);
+        assert_eq!(dto.approval_status, ApprovalStatus::ChangesRequested);
+        assert_eq!(dto.ci_status, CiStatus::Failed);
+        assert_eq!(dto.additions, 250);
+        assert_eq!(dto.deletions, 80);
+        assert_eq!(dto.created_at, "2026-03-01T12:00:00Z");
+        assert_eq!(dto.updated_at, "2026-03-15T18:30:00Z");
+    }
+
+    #[test]
+    fn from_pull_request_with_different_status_variants() {
+        use crate::entity::PullRequest;
+
+        let pr = PullRequest::new(
+            "PR_789".to_string(),
+            1,
+            "Fix typo in README".to_string(),
+            "contributor".to_string(),
+            "https://github.com/org/repo/pull/1".to_string(),
+            "org/repo".to_string(),
+            false,
+            ApprovalStatus::Approved,
+            CiStatus::Passed,
+            0,
+            0,
+            "2026-03-20T00:00:00Z".to_string(),
+            "2026-03-21T10:00:00Z".to_string(),
+        )
+        .expect("test PR should be valid");
+
+        let dto = PrItemDto::from(&pr);
+
+        assert_eq!(dto.id, "PR_789");
+        assert_eq!(dto.number, 1);
+        assert_eq!(dto.title, "Fix typo in README");
+        assert_eq!(dto.author, "contributor");
+        assert_eq!(dto.url, "https://github.com/org/repo/pull/1");
+        assert_eq!(dto.repository, "org/repo");
+        assert!(!dto.is_draft);
+        assert_eq!(dto.approval_status, ApprovalStatus::Approved);
+        assert_eq!(dto.ci_status, CiStatus::Passed);
+        assert_eq!(dto.additions, 0);
+        assert_eq!(dto.deletions, 0);
+        assert_eq!(dto.created_at, "2026-03-20T00:00:00Z");
+        assert_eq!(dto.updated_at, "2026-03-21T10:00:00Z");
     }
 }

--- a/rust-core/crates/usecase/src/process.rs
+++ b/rust-core/crates/usecase/src/process.rs
@@ -15,11 +15,11 @@ pub fn process_pull_requests(login: &str, pull_requests: Vec<PullRequest>) -> Pr
     sort_by_updated_at_desc(&mut classified.my_prs);
     sort_by_updated_at_desc(&mut classified.review_requests);
 
-    let my_items: Vec<PrItemDto> = classified.my_prs.iter().map(to_pr_item_dto).collect();
+    let my_items: Vec<PrItemDto> = classified.my_prs.iter().map(PrItemDto::from).collect();
     let review_items: Vec<PrItemDto> = classified
         .review_requests
         .iter()
-        .map(to_pr_item_dto)
+        .map(PrItemDto::from)
         .collect();
 
     let my_prs = PrListDto {
@@ -37,24 +37,6 @@ pub fn process_pull_requests(login: &str, pull_requests: Vec<PullRequest>) -> Pr
     ProcessedPrs {
         my_prs,
         review_requests,
-    }
-}
-
-fn to_pr_item_dto(pr: &PullRequest) -> PrItemDto {
-    PrItemDto {
-        id: pr.id().to_string(),
-        number: pr.number(),
-        title: pr.title().to_string(),
-        author: pr.author().to_string(),
-        url: pr.url().to_string(),
-        repository: pr.repository().to_string(),
-        is_draft: pr.is_draft(),
-        approval_status: pr.approval_status(),
-        ci_status: pr.ci_status(),
-        additions: pr.additions(),
-        deletions: pr.deletions(),
-        created_at: pr.created_at().to_string(),
-        updated_at: pr.updated_at().to_string(),
     }
 }
 


### PR DESCRIPTION
## 概要
PullRequest → PrItemDto の変換を `From` トレイトで実装し、フィールド追加時の不整合リスクをコンパイル時に検出可能にした。usecase 層のプライベート関数 `to_pr_item_dto` を削除し、Rust の慣用的パターンに統一。

## 変更内容
- `rust-core/crates/domain/src/dto.rs`: `impl From<&PullRequest> for PrItemDto` を追加。構造体リテラル `Self { ... }` でフィールド追加時のコンパイルエラーを保証
- `rust-core/crates/domain/src/dto.rs`: テスト2件追加 (`from_pull_request_produces_matching_dto`, `from_pull_request_with_different_status_variants`)
- `rust-core/crates/usecase/src/process.rs`: `to_pr_item_dto` 関数を削除し `.map(PrItemDto::from)` に置き換え

## 関連 Issue
- closes #44

## テスト
- [x] TypeScript 型チェック通過 (`pnpm check`)
- [x] フロントエンドテスト通過 (`pnpm test`) — 215 tests passed
- [x] Rust lint 通過 (`cargo clippy --all-targets`)
- [x] Rust テスト通過 (`cargo test`) — 78 tests passed
- [x] `/verify` で検証ループ PASS

## レビュー観点
- `From<&PullRequest>` (借用) を選択した設計判断: sort 後に `iter()` で借用イテレータを使うため `&PullRequest` を受ける方が自然。String フィールドは `.to_string()` でコピーが必要なので owned を受けてもコスト同等
- 構造体リテラルによるコンパイル時フィールド対応保証: `PrItemDto` にフィールドが追加されたら `From` 実装が missing field でコンパイルエラーになる
- アーキテクチャ懸念 (domain crate の WASM 依存) は既存設計の問題として #102 で Issue 化済み