### PR TITLE
fix: token exchange エラーメッセージから HTTP ステータス詳細を除去

### DIFF
--- a/src/adapter/chrome/identity.adapter.ts
+++ b/src/adapter/chrome/identity.adapter.ts
@@ -58,15 +58,19 @@ export class ChromeIdentityAdapter implements AuthPort {
 				redirect: "error",
 			});
 		} catch (error: unknown) {
-			const message = error instanceof Error ? error.message : "Unknown error";
+			if (import.meta.env.DEV) {
+				console.error("[identity.adapter] Device code request failed:", error);
+			}
 			throw new AuthError("device_code_request_failed", "Device code request failed");
 		}
 
 		if (!response.ok) {
-			throw new AuthError(
-				"device_code_request_failed",
-				`Device code request failed: ${response.status} ${response.statusText}`,
-			);
+			if (import.meta.env.DEV) {
+				console.error(
+					`[identity.adapter] Device code request failed: ${response.status} ${response.statusText}`,
+				);
+			}
+			throw new AuthError("device_code_request_failed", "Device code request failed");
 		}
 
 		const data = (await response.json()) as Record<string, unknown>;
@@ -95,12 +99,17 @@ export class ChromeIdentityAdapter implements AuthPort {
 				redirect: "error",
 			});
 		} catch (error: unknown) {
-			const message = error instanceof Error ? error.message : "Unknown error";
+			if (import.meta.env.DEV) {
+				console.error("[identity.adapter] Token polling failed:", error);
+			}
 			throw new AuthError("token_exchange_failed", "Token polling failed");
 		}
 
 		if (!response.ok) {
-			throw new AuthError("token_exchange_failed", `Token polling failed: ${response.status}`);
+			if (import.meta.env.DEV) {
+				console.error(`[identity.adapter] Token polling failed: ${response.status}`);
+			}
+			throw new AuthError("token_exchange_failed", "Token polling failed");
 		}
 
 		const data = (await response.json()) as Record<string, unknown>;
@@ -128,7 +137,7 @@ export class ChromeIdentityAdapter implements AuthPort {
 					if (import.meta.env.DEV) {
 						console.warn("[identity.adapter] OAuth error_description:", description);
 					}
-					throw new AuthError("token_exchange_failed", `Token exchange failed: ${description}`);
+					throw new AuthError("token_exchange_failed", "Token exchange failed");
 				}
 			}
 		}

--- a/src/test/adapter/chrome/identity.adapter.test.ts
+++ b/src/test/adapter/chrome/identity.adapter.test.ts
@@ -179,6 +179,7 @@ describe("ChromeIdentityAdapter — Device Flow", () => {
 			const error = await adapter.requestDeviceCode().catch((e: unknown) => e);
 			expect(error).toBeInstanceOf(AuthError);
 			expect((error as AuthError).code).toBe("device_code_request_failed");
+			expect((error as AuthError).message).toBe("Device code request failed");
 		});
 
 		it("should throw AuthError when fetch rejects with network error", async () => {
@@ -275,6 +276,7 @@ describe("ChromeIdentityAdapter — Device Flow", () => {
 
 			expect(error).toBeInstanceOf(AuthError);
 			expect((error as AuthError).code).toBe("token_exchange_failed");
+			expect((error as AuthError).message).toBe("Token polling failed");
 		});
 
 		it("should throw AuthError when HTTP response is not ok", async () => {
@@ -289,6 +291,7 @@ describe("ChromeIdentityAdapter — Device Flow", () => {
 
 			expect(error).toBeInstanceOf(AuthError);
 			expect((error as AuthError).code).toBe("token_exchange_failed");
+			expect((error as AuthError).message).toBe("Token polling failed");
 		});
 
 		it("should POST to tokenEndpoint with correct grant_type and device_code", async () => {
@@ -387,226 +390,8 @@ describe("ChromeIdentityAdapter — Device Flow", () => {
 			expect(savedToken.refreshToken).toBeUndefined();
 		});
 
-		describe("error_description のサニタイズ", () => {
-			/** エラーメッセージから "Token exchange failed: " プレフィックスを除いた description 部分を取得する */
-			function extractDescription(authError: AuthError): string {
-				return authError.message.replace("Token exchange failed: ", "");
-			}
-
-			it("長すぎる error_description を切り詰める (600文字 → 500文字)", async () => {
-				const longDescription = "a".repeat(600);
-				globalThis.fetch = vi.fn().mockResolvedValue({
-					ok: true,
-					json: async () => ({
-						error: "unknown_error",
-						error_description: longDescription,
-					}),
-				});
-
-				const error = await adapter
-					.pollForToken(MOCK_DEVICE_CODE_RESPONSE.deviceCode)
-					.catch((e: unknown) => e);
-
-				expect(error).toBeInstanceOf(AuthError);
-				const description = extractDescription(error as AuthError);
-				expect(description).toHaveLength(500);
-			});
-
-			it("501文字の error_description を500文字に切り詰める", async () => {
-				const description501 = "b".repeat(501);
-				globalThis.fetch = vi.fn().mockResolvedValue({
-					ok: true,
-					json: async () => ({
-						error: "unknown_error",
-						error_description: description501,
-					}),
-				});
-
-				const error = await adapter
-					.pollForToken(MOCK_DEVICE_CODE_RESPONSE.deviceCode)
-					.catch((e: unknown) => e);
-
-				expect(error).toBeInstanceOf(AuthError);
-				const description = extractDescription(error as AuthError);
-				expect(description).toHaveLength(500);
-			});
-
-			it("500文字ちょうどの error_description は切り詰められない", async () => {
-				const description500 = "c".repeat(500);
-				globalThis.fetch = vi.fn().mockResolvedValue({
-					ok: true,
-					json: async () => ({
-						error: "unknown_error",
-						error_description: description500,
-					}),
-				});
-
-				const error = await adapter
-					.pollForToken(MOCK_DEVICE_CODE_RESPONSE.deviceCode)
-					.catch((e: unknown) => e);
-
-				expect(error).toBeInstanceOf(AuthError);
-				const description = extractDescription(error as AuthError);
-				expect(description).toHaveLength(500);
-			});
-
-			it("HTML タグを除去する (<script>)", async () => {
-				globalThis.fetch = vi.fn().mockResolvedValue({
-					ok: true,
-					json: async () => ({
-						error: "unknown_error",
-						error_description: "<script>alert('xss')</script>",
-					}),
-				});
-
-				const error = await adapter
-					.pollForToken(MOCK_DEVICE_CODE_RESPONSE.deviceCode)
-					.catch((e: unknown) => e);
-
-				expect(error).toBeInstanceOf(AuthError);
-				const authError = error as AuthError;
-				expect(authError.message).not.toContain("<script>");
-				expect(authError.message).not.toContain("</script>");
-				expect(authError.message).toContain("alert('xss')");
-			});
-
-			it("HTML タグを除去する (<img onerror>)", async () => {
-				globalThis.fetch = vi.fn().mockResolvedValue({
-					ok: true,
-					json: async () => ({
-						error: "unknown_error",
-						error_description: '<img onerror="alert(1)">payload',
-					}),
-				});
-
-				const error = await adapter
-					.pollForToken(MOCK_DEVICE_CODE_RESPONSE.deviceCode)
-					.catch((e: unknown) => e);
-
-				expect(error).toBeInstanceOf(AuthError);
-				const authError = error as AuthError;
-				expect(authError.message).not.toContain("<img");
-				expect(authError.message).not.toContain("onerror");
-				expect(authError.message).toContain("payload");
-			});
-
-			it("制御文字を除去する (タブ・LF は許容、CR は除去)", async () => {
-				const descriptionWithControlChars = `error${String.fromCharCode(0)}${String.fromCharCode(1)}msg`;
-				globalThis.fetch = vi.fn().mockResolvedValue({
-					ok: true,
-					json: async () => ({
-						error: "unknown_error",
-						error_description: descriptionWithControlChars,
-					}),
-				});
-
-				const error = await adapter
-					.pollForToken(MOCK_DEVICE_CODE_RESPONSE.deviceCode)
-					.catch((e: unknown) => e);
-
-				expect(error).toBeInstanceOf(AuthError);
-				const authError = error as AuthError;
-				expect(authError.message).toContain("errormsg");
-				// 制御文字 (U+0000 ~ U+001F) のうち、タブ(0x09)・LF(0x0A) のみ許容する
-				const hasProhibitedControlChars = [...authError.message].some((ch) => {
-					const code = ch.charCodeAt(0);
-					return code <= 0x1f && code !== 0x09 && code !== 0x0a;
-				});
-				expect(hasProhibitedControlChars).toBe(false);
-			});
-
-			it("タブ・LF は保持される", async () => {
-				globalThis.fetch = vi.fn().mockResolvedValue({
-					ok: true,
-					json: async () => ({
-						error: "unknown_error",
-						error_description: "line1\tvalue\nline2",
-					}),
-				});
-
-				const error = await adapter
-					.pollForToken(MOCK_DEVICE_CODE_RESPONSE.deviceCode)
-					.catch((e: unknown) => e);
-
-				expect(error).toBeInstanceOf(AuthError);
-				const description = extractDescription(error as AuthError);
-				expect(description).toContain("\t");
-				expect(description).toContain("\n");
-				expect(description).toBe("line1\tvalue\nline2");
-			});
-
-			it("error_description なしで error フォールバック", async () => {
-				globalThis.fetch = vi.fn().mockResolvedValue({
-					ok: true,
-					json: async () => ({
-						error: "custom_err",
-					}),
-				});
-
-				const error = await adapter
-					.pollForToken(MOCK_DEVICE_CODE_RESPONSE.deviceCode)
-					.catch((e: unknown) => e);
-
-				expect(error).toBeInstanceOf(AuthError);
-				const authError = error as AuthError;
-				expect(authError.message).toContain("custom_err");
-			});
-
-			it("error_description が空文字の場合は error フィールドにフォールバック", async () => {
-				globalThis.fetch = vi.fn().mockResolvedValue({
-					ok: true,
-					json: async () => ({
-						error: "fallback_error",
-						error_description: "",
-					}),
-				});
-
-				const error = await adapter
-					.pollForToken(MOCK_DEVICE_CODE_RESPONSE.deviceCode)
-					.catch((e: unknown) => e);
-
-				expect(error).toBeInstanceOf(AuthError);
-				const authError = error as AuthError;
-				expect(authError.message).toContain("fallback_error");
-			});
-
-			it("error_description が null の場合は error フィールドにフォールバック", async () => {
-				globalThis.fetch = vi.fn().mockResolvedValue({
-					ok: true,
-					json: async () => ({
-						error: "null_desc_error",
-						error_description: null,
-					}),
-				});
-
-				const error = await adapter
-					.pollForToken(MOCK_DEVICE_CODE_RESPONSE.deviceCode)
-					.catch((e: unknown) => e);
-
-				expect(error).toBeInstanceOf(AuthError);
-				const authError = error as AuthError;
-				expect(authError.message).toContain("null_desc_error");
-			});
-
-			it("error_description が数値の場合は error フィールドにフォールバック", async () => {
-				globalThis.fetch = vi.fn().mockResolvedValue({
-					ok: true,
-					json: async () => ({
-						error: "numeric_desc_error",
-						error_description: 12345,
-					}),
-				});
-
-				const error = await adapter
-					.pollForToken(MOCK_DEVICE_CODE_RESPONSE.deviceCode)
-					.catch((e: unknown) => e);
-
-				expect(error).toBeInstanceOf(AuthError);
-				const authError = error as AuthError;
-				expect(authError.message).toContain("numeric_desc_error");
-			});
-
-			it("正常な description はそのまま通る", async () => {
+		describe("未知の OAuth エラー", () => {
+			it("未知のエラーでは固定メッセージの AuthError を throw する", async () => {
 				globalThis.fetch = vi.fn().mockResolvedValue({
 					ok: true,
 					json: async () => ({
@@ -621,7 +406,64 @@ describe("ChromeIdentityAdapter — Device Flow", () => {
 
 				expect(error).toBeInstanceOf(AuthError);
 				const authError = error as AuthError;
-				expect(authError.message).toContain("Something went wrong");
+				expect(authError.code).toBe("token_exchange_failed");
+				expect(authError.message).toBe("Token exchange failed");
+			});
+
+			it("error_description の内容がユーザー向けメッセージに漏れない", async () => {
+				globalThis.fetch = vi.fn().mockResolvedValue({
+					ok: true,
+					json: async () => ({
+						error: "unknown_error",
+						error_description: "<script>alert('xss')</script>",
+					}),
+				});
+
+				const error = await adapter
+					.pollForToken(MOCK_DEVICE_CODE_RESPONSE.deviceCode)
+					.catch((e: unknown) => e);
+
+				expect(error).toBeInstanceOf(AuthError);
+				const authError = error as AuthError;
+				expect(authError.message).toBe("Token exchange failed");
+				expect(authError.message).not.toContain("script");
+				expect(authError.message).not.toContain("xss");
+			});
+
+			it("error_description なしでも固定メッセージで throw する", async () => {
+				globalThis.fetch = vi.fn().mockResolvedValue({
+					ok: true,
+					json: async () => ({
+						error: "custom_err",
+					}),
+				});
+
+				const error = await adapter
+					.pollForToken(MOCK_DEVICE_CODE_RESPONSE.deviceCode)
+					.catch((e: unknown) => e);
+
+				expect(error).toBeInstanceOf(AuthError);
+				const authError = error as AuthError;
+				expect(authError.code).toBe("token_exchange_failed");
+				expect(authError.message).toBe("Token exchange failed");
+			});
+
+			it("error_description が空文字の場合も固定メッセージで throw する", async () => {
+				globalThis.fetch = vi.fn().mockResolvedValue({
+					ok: true,
+					json: async () => ({
+						error: "fallback_error",
+						error_description: "",
+					}),
+				});
+
+				const error = await adapter
+					.pollForToken(MOCK_DEVICE_CODE_RESPONSE.deviceCode)
+					.catch((e: unknown) => e);
+
+				expect(error).toBeInstanceOf(AuthError);
+				const authError = error as AuthError;
+				expect(authError.message).toBe("Token exchange failed");
 			});
 		});
 	});


### PR DESCRIPTION
## 概要

AuthError のユーザー向けメッセージから HTTP ステータスコード・statusText・OAuth error_description を除去し、固定文字列に統一。詳細な診断情報は `import.meta.env.DEV` ガード付きの `console.error`/`console.warn` のみに出力する。

## 変更内容

- `src/adapter/chrome/identity.adapter.ts`: `requestDeviceCode()` の catch + `!response.ok` ブロック 2箇所で HTTP ステータス詳細をエラーメッセージから除去、DEV ログに移動。`pollForToken()` の catch + `!response.ok` ブロック 2箇所も同様。default ブランチの `error_description` もエラーメッセージから除去し固定文字列化
- `src/test/adapter/chrome/identity.adapter.test.ts`: 3箇所に `message` アサーション追加（汎用メッセージであることの回帰防止）。error_description サニタイズ詳細テストを固定メッセージ検証テストに変更

## 関連 Issue

- closes #61

## テスト

- [x] TypeScript 型チェック通過 (`pnpm check`)
- [x] フロントエンドテスト通過 (`pnpm test`) — 207/207 PASS
- [x] Rust lint 通過 (`cargo clippy --all-targets`)
- [x] Rust テスト通過 (`cargo test`) — 76/76 PASS
- [x] `/verify` で検証ループ PASS

## レビュー観点

1. `identity.adapter.ts` の5箇所のエラーメッセージ固定化が漏れなく適用されているか
2. `import.meta.env.DEV` ガードのパターンが既存コード（L137-139 の `console.warn`）と一貫しているか
3. テスト削減の妥当性: `error_description` がメッセージに含まれなくなったため、サニタイズ詳細テスト（切り詰め・制御文字除去等）を固定メッセージ検証に置換した判断
4. 関連 Issue #104: `import.meta.env.DEV` ガードの本番ビルド検証を CI に追加する後続タスク