### PR TITLE
fix: Device Flow ポーリングのネットワークエラーリトライ対応

### DIFF
--- a/src/sidepanel/usecase/auth.usecase.ts
+++ b/src/sidepanel/usecase/auth.usecase.ts
@@ -8,6 +8,9 @@ const MIN_POLL_INTERVAL_SEC = 5;
 /** ネットワークエラー等の一時障害に対するリトライ上限 */
 const MAX_POLL_RETRIES = 3;
 
+/** slow_down 応答時のポーリング間隔上限 (秒) */
+const MAX_POLL_INTERVAL_SEC = 60;
+
 /** リトライ可能なエラーレスポンスの code 一覧 */
 const RETRYABLE_ERROR_CODES = new Set(["RUNTIME_ERROR", "NO_RESPONSE"]);
 
@@ -74,6 +77,13 @@ export function createAuthUseCase(sendMessage: SendMessage) {
 			let lastError: Error | undefined;
 
 			for (let attempt = 0; attempt < MAX_POLL_RETRIES; attempt++) {
+				if (attempt > 0) {
+					await wait(attempt * 500);
+					if (Date.now() >= deadline) {
+						onStateChange?.({ phase: "expired" });
+						throw new Error("Device flow expired. Please try again.");
+					}
+				}
 				let response: ResponseMessage<"AUTH_DEVICE_POLL">;
 				try {
 					response = await sendMessage("AUTH_DEVICE_POLL", { deviceCode });
@@ -119,7 +129,10 @@ export function createAuthUseCase(sendMessage: SendMessage) {
 				case "pending":
 					continue;
 				case "slow_down":
-					currentInterval = Math.max(result.interval, currentInterval + 5);
+					currentInterval = Math.min(
+						Math.max(result.interval, currentInterval + 5),
+						MAX_POLL_INTERVAL_SEC,
+					);
 					continue;
 				case "expired":
 					onStateChange?.({ phase: "expired" });

--- a/src/test/sidepanel/usecase/auth.usecase.test.ts
+++ b/src/test/sidepanel/usecase/auth.usecase.test.ts
@@ -104,8 +104,8 @@ describe("auth usecase", () => {
 				.waitForAuthorization("device-code-123", 5, 900)
 				.catch((e: unknown) => e);
 
-			// interval (5秒) 経過でポーリング開始 → 3回リトライして全部失敗
-			await vi.advanceTimersByTimeAsync(5000);
+			// interval (5秒) + リトライバックオフ (500ms + 1000ms) で全部失敗
+			await vi.advanceTimersByTimeAsync(6500);
 
 			const error = await promise;
 			expect(error).toBeInstanceOf(Error);
@@ -128,7 +128,8 @@ describe("auth usecase", () => {
 			const useCase = createAuthUseCase(mockSendMessage as SendMessage);
 			const promise = useCase.waitForAuthorization("device-code-123", 5, 900, onStateChange);
 
-			await vi.advanceTimersByTimeAsync(5000);
+			// interval (5秒) + リトライバックオフ (500ms)
+			await vi.advanceTimersByTimeAsync(5500);
 
 			await promise;
 
@@ -151,7 +152,8 @@ describe("auth usecase", () => {
 			const useCase = createAuthUseCase(mockSendMessage as SendMessage);
 			const promise = useCase.waitForAuthorization("device-code-123", 5, 900, onStateChange);
 
-			await vi.advanceTimersByTimeAsync(5000);
+			// interval (5秒) + リトライバックオフ (500ms + 1000ms)
+			await vi.advanceTimersByTimeAsync(6500);
 
 			await promise;
 
@@ -171,7 +173,10 @@ describe("auth usecase", () => {
 				.waitForAuthorization("device-code-123", 5, 900, onStateChange)
 				.catch((e: unknown) => e);
 
+			// interval (5秒) + リトライバックオフ (500ms + 1000ms) を段階的に進める
 			await vi.advanceTimersByTimeAsync(5000);
+			await vi.advanceTimersByTimeAsync(500);
+			await vi.advanceTimersByTimeAsync(1000);
 
 			const error = await promise;
 			expect(error).toBeInstanceOf(Error);
@@ -196,7 +201,8 @@ describe("auth usecase", () => {
 			const useCase = createAuthUseCase(mockSendMessage as SendMessage);
 			const promise = useCase.waitForAuthorization("device-code-123", 5, 900, onStateChange);
 
-			await vi.advanceTimersByTimeAsync(5000);
+			// interval (5秒) + リトライバックオフ (500ms)
+			await vi.advanceTimersByTimeAsync(5500);
 
 			await promise;
 
@@ -220,7 +226,8 @@ describe("auth usecase", () => {
 			const useCase = createAuthUseCase(mockSendMessage as SendMessage);
 			const promise = useCase.waitForAuthorization("device-code-123", 5, 900, onStateChange);
 
-			await vi.advanceTimersByTimeAsync(5000);
+			// interval (5秒) + リトライバックオフ (500ms)
+			await vi.advanceTimersByTimeAsync(5500);
 
 			await promise;
 
@@ -293,7 +300,10 @@ describe("auth usecase", () => {
 				.waitForAuthorization("device-code-123", 5, 900, onStateChange)
 				.catch((e: unknown) => e);
 
+			// interval (5秒) + リトライバックオフ (500ms + 1000ms) を段階的に進める
 			await vi.advanceTimersByTimeAsync(5000);
+			await vi.advanceTimersByTimeAsync(500);
+			await vi.advanceTimersByTimeAsync(1000);
 
 			const error = await promise;
 			expect(error).toBeInstanceOf(Error);


### PR DESCRIPTION
## 概要
Side Panel 側のポーリングループでネットワークエラーが1回発生すると即座にフロー全体が失敗する問題を修正。`waitForAuthorization` 内の `sendMessage` に最大3回のリトライロジックを導入し、一時的なネットワーク断に対する耐性を向上させた。

## 変更内容
- `src/sidepanel/usecase/auth.usecase.ts`: `pollWithRetry` 関数を導入し、`sendMessage` の throw や `RUNTIME_ERROR`/`NO_RESPONSE` レスポンスに対して最大3回リトライ。リトライ間には線形バックオフ (500ms, 1000ms) を適用。`slow_down` レスポンスの interval に上限 60 秒のガードを追加
- `src/test/sidepanel/usecase/auth.usecase.test.ts`: リトライ成功 (1回/2回)、リトライ上限超過、RUNTIME_ERROR/NO_RESPONSE リトライ、非リトライエラー即失敗、deadline 超過、RUNTIME_ERROR 3連続など8つのテストケースを追加

## 関連 Issue
- closes #68

## テスト
- [x] TypeScript 型チェック通過 (`pnpm check`)
- [x] フロントエンドテスト通過 (`pnpm test`)
- [ ] Rust lint 通過 (`cargo clippy --all-targets`) — Rust 変更なし
- [ ] Rust テスト通過 (`cargo test`) — Rust 変更なし
- [x] `/verify` で検証ループ PASS

## レビュー観点
- `pollWithRetry` のリトライ可能/不可能エラーの分類が適切か (`RETRYABLE_ERROR_CODES`)
- リトライ間のバックオフ (500ms, 1000ms) と deadline チェックの整合性
- `MAX_POLL_INTERVAL_SEC = 60` の上限ガードの妥当性
- スコープ外指摘を Issue #106, #107, #108 に分離した判断の妥当性