### PR TITLE
feat: ビルド時シークレット漏洩防止ガードを追加

### DIFF
--- a/.claude/rules/security.md
+++ b/.claude/rules/security.md
@@ -6,11 +6,13 @@ IMPORTANT: これらのルールは常に適用される。例外は認めない
 - OAuth client_secret、access_token をソースコードにハードコードしない
 - `.env` ファイルは `.gitignore` に含める
 - `chrome.storage.local` に保存する token は最小スコープで取得する
+- `vite.config.ts` のシークレット漏洩防止ガード (`validateBuildEnv`) を維持すること
 
-## OAuth
-- PKCE フローを使用する (OAuth App でも可能な限り)
-- state パラメータで CSRF を防ぐ
-- redirect_uri は厳密に固定する
+## OAuth (Device Flow)
+- GitHub OAuth App の Device Flow を使用する (client_secret 不要)
+- `client_id` はバンドルに含まれるが、Device Flow では公開情報として許容される
+- `client_secret` は一切使用しない。環境変数に設定された場合はビルドガードが検出する
+- token リフレッシュは `client_id` + `refresh_token` のみで行う
 
 ## API 通信
 - GitHub API 呼び出しは HTTPS のみ

--- a/src/adapter/chrome/oauth.config.ts
+++ b/src/adapter/chrome/oauth.config.ts
@@ -1,3 +1,5 @@
+// Security: client_id は OAuth Device Flow では公開情報。
+// client_secret は不要であり、バンドルに含めてはならない。
 export type OAuthConfig = {
 	readonly clientId: string;
 	readonly deviceCodeEndpoint: string;

--- a/src/shared/config/env-guard.ts
+++ b/src/shared/config/env-guard.ts
@@ -1,0 +1,24 @@
+// 新しいシークレット系環境変数を導入したらここに追加すること
+const FORBIDDEN_KEYS = [
+	"GITHUB_CLIENT_SECRET",
+	"GITHUB_OAUTH_SECRET",
+	"GITHUB_TOKEN",
+	"GH_TOKEN",
+	"GITHUB_PAT",
+	"GITHUB_ACCESS_TOKEN",
+] as const;
+
+/**
+ * ビルド環境にシークレットが混入していないことを検証する。
+ * vite.config.ts から呼び出し、ビルド時にガードする。
+ */
+export function validateBuildEnv(env: Record<string, string | undefined>): void {
+	// 空文字は falsy なのでここで除外される。空文字はバンドルに混入しても実害がないため意図的に許容している
+	const found = FORBIDDEN_KEYS.filter((key) => env[key]);
+
+	if (found.length > 0) {
+		throw new Error(
+			`SECURITY: ${found.join(", ")} is set in environment. These secrets must not be present during build to prevent bundle contamination.`,
+		);
+	}
+}

--- a/src/test/shared/config/env-guard.test.ts
+++ b/src/test/shared/config/env-guard.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import { validateBuildEnv } from "../../../shared/config/env-guard";
+
+describe("validateBuildEnv", () => {
+	it("should not throw when all forbidden keys are absent", () => {
+		const env: Record<string, string | undefined> = {};
+		expect(() => validateBuildEnv(env)).not.toThrow();
+	});
+
+	it("should throw when GITHUB_CLIENT_SECRET is set", () => {
+		const env: Record<string, string | undefined> = {
+			GITHUB_CLIENT_SECRET: "super-secret",
+		};
+		expect(() => validateBuildEnv(env)).toThrow("SECURITY:");
+		expect(() => validateBuildEnv(env)).toThrow("GITHUB_CLIENT_SECRET");
+	});
+
+	it("should throw when GITHUB_OAUTH_SECRET is set", () => {
+		const env: Record<string, string | undefined> = {
+			GITHUB_OAUTH_SECRET: "oauth-secret-value",
+		};
+		expect(() => validateBuildEnv(env)).toThrow("SECURITY:");
+		expect(() => validateBuildEnv(env)).toThrow("GITHUB_OAUTH_SECRET");
+	});
+
+	it("should throw when GITHUB_TOKEN is set", () => {
+		const env: Record<string, string | undefined> = {
+			GITHUB_TOKEN: "ghp_xxxxxxxxxxxx",
+		};
+		expect(() => validateBuildEnv(env)).toThrow("SECURITY:");
+		expect(() => validateBuildEnv(env)).toThrow("GITHUB_TOKEN");
+	});
+
+	it("should throw when GH_TOKEN is set", () => {
+		const env: Record<string, string | undefined> = {
+			GH_TOKEN: "ghp_yyyyyyyyyyyy",
+		};
+		expect(() => validateBuildEnv(env)).toThrow("SECURITY:");
+		expect(() => validateBuildEnv(env)).toThrow(/\bGH_TOKEN\b/);
+	});
+
+	it("should throw when GITHUB_PAT is set", () => {
+		const env: Record<string, string | undefined> = {
+			GITHUB_PAT: "ghp_patvalue",
+		};
+		expect(() => validateBuildEnv(env)).toThrow("SECURITY:");
+		expect(() => validateBuildEnv(env)).toThrow("GITHUB_PAT");
+	});
+
+	it("should throw when GITHUB_ACCESS_TOKEN is set", () => {
+		const env: Record<string, string | undefined> = {
+			GITHUB_ACCESS_TOKEN: "gho_accesstoken",
+		};
+		expect(() => validateBuildEnv(env)).toThrow("SECURITY:");
+		expect(() => validateBuildEnv(env)).toThrow("GITHUB_ACCESS_TOKEN");
+	});
+
+	it("should not throw when forbidden keys are explicitly undefined", () => {
+		const env: Record<string, string | undefined> = {
+			GITHUB_TOKEN: undefined,
+			GH_TOKEN: undefined,
+		};
+		expect(() => validateBuildEnv(env)).not.toThrow();
+	});
+
+	it("should throw when multiple forbidden keys are set at once", () => {
+		const env: Record<string, string | undefined> = {
+			GITHUB_CLIENT_SECRET: "secret",
+			GITHUB_TOKEN: "token",
+		};
+		expect(() => validateBuildEnv(env)).toThrow("SECURITY:");
+		expect(() => validateBuildEnv(env)).toThrow("GITHUB_CLIENT_SECRET");
+		expect(() => validateBuildEnv(env)).toThrow("GITHUB_TOKEN");
+	});
+
+	it("should not throw when forbidden keys are empty strings", () => {
+		const env: Record<string, string | undefined> = {
+			GITHUB_CLIENT_SECRET: "",
+			GITHUB_OAUTH_SECRET: "",
+			GITHUB_TOKEN: "",
+			GH_TOKEN: "",
+			GITHUB_PAT: "",
+			GITHUB_ACCESS_TOKEN: "",
+		};
+		expect(() => validateBuildEnv(env)).not.toThrow();
+	});
+
+	it("should not throw when only non-forbidden keys like GITHUB_CLIENT_ID are present", () => {
+		const env: Record<string, string | undefined> = {
+			GITHUB_CLIENT_ID: "my-client-id",
+			SOME_OTHER_VAR: "some-value",
+		};
+		expect(() => validateBuildEnv(env)).not.toThrow();
+	});
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,10 +2,15 @@ import { crx } from "@crxjs/vite-plugin";
 import { svelte } from "@sveltejs/vite-plugin-svelte";
 import { defineConfig } from "vite";
 import manifest from "./manifest.config";
+import { validateBuildEnv } from "./src/shared/config/env-guard";
 
 const isViteBuild = process.argv.includes("build");
 
 export default defineConfig(() => {
+	if (isViteBuild) {
+		validateBuildEnv(process.env as Record<string, string | undefined>);
+	}
+
 	const clientId = process.env.GITHUB_CLIENT_ID ?? "";
 	if (isViteBuild && !clientId) {
 		throw new Error("GITHUB_CLIENT_ID must be set for production builds");


### PR DESCRIPTION
## 概要
Issue #62 で指摘された OAuth シークレットの Chrome 拡張バンドル埋め込みリスクに対応。現状は Device Flow 採用済みで OAuth secret はコードに存在しないが、将来の誤設定を防ぐビルド時ガードを追加し、セキュリティルールを Device Flow 前提に更新した。

## 変更内容
- `src/shared/config/env-guard.ts`: ビルド環境のシークレット混入を検証する `validateBuildEnv()` 関数を新規作成。6つの禁止環境変数キーを検出してビルドを失敗させる
- `src/test/shared/config/env-guard.test.ts`: env-guard の 11 テストケース（各禁止キー検出、空文字/undefined 許容、複数キー同時検出、非禁止キー許容）
- `vite.config.ts`: ビルド時に `validateBuildEnv(process.env)` を呼び出すガードを統合
- `src/adapter/chrome/oauth.config.ts`: Device Flow で client_id が公開情報である旨のセキュリティコメント追加
- `.claude/rules/security.md`: OAuth セクションを Device Flow 前提に更新。ビルドガード維持ルールを追加

## 関連 Issue
- closes #62

## テスト
- [x] TypeScript 型チェック通過 (`pnpm check`)
- [x] フロントエンドテスト通過 (`pnpm test`) — 226 tests, 18 suites
- [x] Rust lint 通過 (`cargo clippy --all-targets`)
- [x] Rust テスト通過 (`cargo test`) — 37 tests
- [x] `/verify` で検証ループ PASS

## レビュー観点
- `validateBuildEnv` がビルド時のみ実行される設計判断：開発環境に GitHub CLI 用トークンが存在するため、dev サーバー時には実行しない。ガードの目的は Vite の `define` によるバンドル混入防止なので build 限定で正しいか
- 禁止キーリスト（6キー）の網羅性
- 空文字を許容する設計判断：空文字はバンドルに混入しても実害がないため falsy チェックで除外
