### PR TITLE
feat: HTTP 429/403 rate limit の Retry-After ベースリトライ対応

### DIFF
--- a/src/adapter/github/graphql-client.ts
+++ b/src/adapter/github/graphql-client.ts
@@ -7,8 +7,8 @@ import type {
 } from "../../domain/types/github";
 import { GitHubApiError } from "../../shared/types/errors";
 import { extractRateLimitInfo } from "./rate-limit";
-import type { RetryConfig } from "./retry";
-import { withRetry } from "./retry";
+import type { DelayFn, RetryConfig } from "./retry";
+import { defaultDelay, withRetry } from "./retry";
 
 const GRAPHQL_ENDPOINT = "https://api.github.com/graphql";
 
@@ -112,21 +112,45 @@ const DEFAULT_RETRY_CONFIG: RetryConfig = {
 	maxDelayMs: 10000,
 };
 
-function shouldRetryError(error: unknown): boolean {
+const MAX_RATE_LIMIT_RETRIES = 1;
+
+/** Chrome Service Worker の 5分タイムアウトを考慮した Retry-After 上限 */
+const MAX_RETRY_AFTER_MS = 120_000;
+
+type GitHubApiErrorWithRetryAfter = GitHubApiError & { readonly retryAfter: number };
+
+function hasValidRetryAfter(error: unknown): error is GitHubApiErrorWithRetryAfter {
+	return error instanceof GitHubApiError && error.retryAfter != null && error.retryAfter > 0;
+}
+
+function shouldRetryError(error: unknown, attempt: number): boolean {
 	if (error instanceof GitHubApiError) {
-		return error.code === "server_error" || error.code === "network_error";
+		if (error.code === "server_error" || error.code === "network_error") return true;
+		if (error.code === "rate_limited" && hasValidRetryAfter(error)) {
+			return attempt < MAX_RATE_LIMIT_RETRIES;
+		}
 	}
 	return false;
 }
 
+function getRateLimitDelay(error: unknown): number | undefined {
+	if (hasValidRetryAfter(error)) {
+		return Math.min(error.retryAfter * 1000, MAX_RETRY_AFTER_MS);
+	}
+	return undefined;
+}
+
 export class GitHubGraphQLClient implements GitHubApiPort {
 	private readonly retryConfig: RetryConfig;
+	private readonly delayFn: DelayFn;
 
 	constructor(
 		private readonly getAccessToken: () => Promise<string>,
 		retryConfig?: Partial<RetryConfig>,
+		delayFn?: DelayFn,
 	) {
 		this.retryConfig = { ...DEFAULT_RETRY_CONFIG, ...retryConfig };
+		this.delayFn = delayFn ?? defaultDelay;
 	}
 
 	async fetchPullRequests(): Promise<FetchPullRequestsResult> {
@@ -135,6 +159,8 @@ export class GitHubGraphQLClient implements GitHubApiPort {
 			() => this.executeQuery(token),
 			this.retryConfig,
 			shouldRetryError,
+			this.delayFn,
+			{ getDelayOverride: getRateLimitDelay },
 		);
 		const body = await this.parseResponseBody(response);
 
@@ -190,6 +216,21 @@ export class GitHubGraphQLClient implements GitHubApiPort {
 		if (!response.ok) {
 			const errorCode = mapHttpStatusToErrorCode(response.status);
 			const message = `GitHub API error: ${response.status} ${response.statusText}`;
+
+			if (response.status === 403) {
+				const rateLimitInfo = extractRateLimitInfo(response.headers);
+				if (rateLimitInfo && rateLimitInfo.remaining === 0) {
+					const retryAfterStr = response.headers.get("Retry-After");
+					const retryAfter =
+						retryAfterStr !== null && Number.isFinite(Number(retryAfterStr))
+							? Number(retryAfterStr)
+							: undefined;
+					throw new GitHubApiError("rate_limited", message, response.status, undefined, {
+						retryAfter,
+						rateLimitRemaining: rateLimitInfo.remaining,
+					});
+				}
+			}
 
 			if (response.status === 429) {
 				const retryAfterStr = response.headers.get("Retry-After");

--- a/src/adapter/github/retry.ts
+++ b/src/adapter/github/retry.ts
@@ -7,17 +7,22 @@ export type RetryConfig = {
 
 export type DelayFn = (ms: number) => Promise<void>;
 
-const defaultDelay: DelayFn = (ms: number) =>
+export const defaultDelay: DelayFn = (ms: number) =>
 	new Promise((resolve) => {
 		const jitter = ms * Math.random() * 0.5;
 		setTimeout(resolve, ms + jitter);
 	});
 
+export type WithRetryOptions = {
+	readonly getDelayOverride?: (error: unknown) => number | undefined;
+};
+
 export async function withRetry<T>(
 	fn: () => Promise<T>,
 	config: RetryConfig,
-	shouldRetry: (error: unknown) => boolean,
+	shouldRetry: (error: unknown, attempt: number) => boolean,
 	delay: DelayFn = defaultDelay,
+	options?: WithRetryOptions,
 ): Promise<T> {
 	let attempt = 0;
 
@@ -25,11 +30,15 @@ export async function withRetry<T>(
 		try {
 			return await fn();
 		} catch (error: unknown) {
-			if (!shouldRetry(error) || attempt >= config.maxRetries) {
+			if (!shouldRetry(error, attempt) || attempt >= config.maxRetries) {
 				throw error;
 			}
 
-			const delayMs = Math.min(config.baseDelayMs * 2 ** attempt, config.maxDelayMs);
+			const overrideMs = options?.getDelayOverride?.(error);
+			const delayMs =
+				overrideMs !== undefined
+					? Math.max(0, overrideMs)
+					: Math.min(config.baseDelayMs * 2 ** attempt, config.maxDelayMs);
 			await delay(delayMs);
 			attempt++;
 		}

--- a/src/test/adapter/github/graphql-client.test.ts
+++ b/src/test/adapter/github/graphql-client.test.ts
@@ -1,8 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { GitHubGraphQLClient } from "../../../adapter/github/graphql-client";
+import type { DelayFn } from "../../../adapter/github/retry";
 import type { GitHubApiPort } from "../../../domain/ports/github-api.port";
 import type { ReviewDecision, StatusState } from "../../../domain/types/github";
 import { GitHubApiError } from "../../../shared/types/errors";
+
+const noDelay: DelayFn = () => Promise.resolve();
 
 const GRAPHQL_ENDPOINT = "https://api.github.com/graphql";
 const TEST_TOKEN = "gho_test_access_token_12345";
@@ -321,6 +324,7 @@ describe("GitHubGraphQLClient", () => {
 				ok: false,
 				status: 403,
 				statusText: "Forbidden",
+				headers: new Headers(),
 			});
 
 			const error = await client.fetchPullRequests().catch((e: unknown) => e);
@@ -495,7 +499,11 @@ describe("GitHubGraphQLClient", () => {
 		let retryClient: GitHubApiPort;
 
 		beforeEach(() => {
-			retryClient = new GitHubGraphQLClient(mockGetAccessToken, { baseDelayMs: 1, maxDelayMs: 1 });
+			retryClient = new GitHubGraphQLClient(
+				mockGetAccessToken,
+				{ baseDelayMs: 1, maxDelayMs: 1 },
+				noDelay,
+			);
 		});
 
 		it("should retry on 5xx and succeed on 4th attempt", async () => {
@@ -596,7 +604,7 @@ describe("GitHubGraphQLClient", () => {
 			expect(fetchMock).toHaveBeenCalledTimes(1);
 		});
 
-		it("should not retry on 429", async () => {
+		it("should not retry on 429 without Retry-After", async () => {
 			const fetchMock = vi.fn().mockResolvedValue({
 				ok: false,
 				status: 429,
@@ -609,6 +617,7 @@ describe("GitHubGraphQLClient", () => {
 
 			expect(error).toBeInstanceOf(GitHubApiError);
 			expect((error as GitHubApiError).code).toBe("rate_limited");
+			// Retry-After なしなのでリトライしない → fetch 1回だけ
 			expect(fetchMock).toHaveBeenCalledTimes(1);
 		});
 
@@ -648,6 +657,218 @@ describe("GitHubGraphQLClient", () => {
 			expect(result.myPrs).toEqual([]);
 			expect(result.reviewRequested).toEqual([]);
 			expect(result.hasMore).toBe(false);
+		});
+
+		it("should retry once on 429 with Retry-After and succeed", async () => {
+			const fetchMock = vi
+				.fn()
+				.mockResolvedValueOnce({
+					ok: false,
+					status: 429,
+					statusText: "Too Many Requests",
+					headers: new Headers({
+						"Retry-After": "30",
+						"X-RateLimit-Remaining": "0",
+						"X-RateLimit-Reset": String(Math.floor(Date.now() / 1000) + 30),
+						"X-RateLimit-Limit": "5000",
+					}),
+				})
+				.mockResolvedValueOnce({
+					ok: true,
+					json: async () => createSuccessResponse(),
+				});
+			globalThis.fetch = fetchMock;
+
+			const result = await retryClient.fetchPullRequests();
+
+			expect(result.myPrs).toEqual([]);
+			// 429 + Retry-After ありなので 1回リトライ → fetch 2回
+			expect(fetchMock).toHaveBeenCalledTimes(2);
+		});
+
+		it("should not retry on 429 when Retry-After is absent", async () => {
+			const fetchMock = vi.fn().mockResolvedValue({
+				ok: false,
+				status: 429,
+				statusText: "Too Many Requests",
+				headers: new Headers({
+					"X-RateLimit-Remaining": "0",
+					"X-RateLimit-Reset": String(Math.floor(Date.now() / 1000) + 60),
+					"X-RateLimit-Limit": "5000",
+				}),
+			});
+			globalThis.fetch = fetchMock;
+
+			const error = await retryClient.fetchPullRequests().catch((e: unknown) => e);
+
+			expect(error).toBeInstanceOf(GitHubApiError);
+			expect((error as GitHubApiError).code).toBe("rate_limited");
+			// Retry-After なし → リトライしない → fetch 1回
+			expect(fetchMock).toHaveBeenCalledTimes(1);
+		});
+
+		it("should limit rate_limited retry to 1 attempt even with multiple 429 responses", async () => {
+			const fetchMock = vi.fn().mockResolvedValue({
+				ok: false,
+				status: 429,
+				statusText: "Too Many Requests",
+				headers: new Headers({
+					"Retry-After": "10",
+					"X-RateLimit-Remaining": "0",
+					"X-RateLimit-Reset": String(Math.floor(Date.now() / 1000) + 10),
+					"X-RateLimit-Limit": "5000",
+				}),
+			});
+			globalThis.fetch = fetchMock;
+
+			const error = await retryClient.fetchPullRequests().catch((e: unknown) => e);
+
+			expect(error).toBeInstanceOf(GitHubApiError);
+			expect((error as GitHubApiError).code).toBe("rate_limited");
+			// rate limit リトライは最大1回 → 初回 + リトライ1回 = fetch 2回
+			expect(fetchMock).toHaveBeenCalledTimes(2);
+		});
+
+		it("should treat 403 with X-RateLimit-Remaining: 0 as rate_limited", async () => {
+			const fetchMock = vi.fn().mockResolvedValue({
+				ok: false,
+				status: 403,
+				statusText: "Forbidden",
+				headers: new Headers({
+					"X-RateLimit-Remaining": "0",
+					"X-RateLimit-Reset": String(Math.floor(Date.now() / 1000) + 60),
+					"X-RateLimit-Limit": "5000",
+				}),
+			});
+			globalThis.fetch = fetchMock;
+
+			const error = await retryClient.fetchPullRequests().catch((e: unknown) => e);
+
+			expect(error).toBeInstanceOf(GitHubApiError);
+			// 403 + X-RateLimit-Remaining: 0 は rate_limited として扱う
+			expect((error as GitHubApiError).code).toBe("rate_limited");
+		});
+
+		it("should treat 403 with X-RateLimit-Remaining > 0 as forbidden", async () => {
+			const fetchMock = vi.fn().mockResolvedValue({
+				ok: false,
+				status: 403,
+				statusText: "Forbidden",
+				headers: new Headers({
+					"X-RateLimit-Remaining": "100",
+					"X-RateLimit-Reset": String(Math.floor(Date.now() / 1000) + 60),
+					"X-RateLimit-Limit": "5000",
+				}),
+			});
+			globalThis.fetch = fetchMock;
+
+			const error = await retryClient.fetchPullRequests().catch((e: unknown) => e);
+
+			expect(error).toBeInstanceOf(GitHubApiError);
+			// X-RateLimit-Remaining: 100 → 通常の forbidden
+			expect((error as GitHubApiError).code).toBe("forbidden");
+		});
+
+		it("should retry on 429 with Retry-After: 5 and return success response on 2nd attempt", async () => {
+			const prEdge = createPrEdge({ title: "Recovered PR", number: 42 });
+			const fetchMock = vi
+				.fn()
+				.mockResolvedValueOnce({
+					ok: false,
+					status: 429,
+					statusText: "Too Many Requests",
+					headers: new Headers({
+						"Retry-After": "5",
+						"X-RateLimit-Remaining": "0",
+						"X-RateLimit-Reset": String(Math.floor(Date.now() / 1000) + 5),
+						"X-RateLimit-Limit": "5000",
+					}),
+				})
+				.mockResolvedValueOnce({
+					ok: true,
+					json: async () => createSuccessResponse([prEdge]),
+				});
+			globalThis.fetch = fetchMock;
+
+			const result = await retryClient.fetchPullRequests();
+
+			// 429 + Retry-After ありなのでリトライ → 2回目で成功
+			expect(fetchMock).toHaveBeenCalledTimes(2);
+			expect(result.myPrs).toHaveLength(1);
+			expect(result.myPrs[0].title).toBe("Recovered PR");
+			expect(result.myPrs[0].number).toBe(42);
+		});
+
+		it("should treat 403 with X-RateLimit-Remaining: 0 as rate_limited error code", async () => {
+			const fetchMock = vi.fn().mockResolvedValue({
+				ok: false,
+				status: 403,
+				statusText: "Forbidden",
+				headers: new Headers({
+					"X-RateLimit-Remaining": "0",
+					"X-RateLimit-Reset": String(Math.floor(Date.now() / 1000) + 120),
+					"X-RateLimit-Limit": "5000",
+				}),
+			});
+			globalThis.fetch = fetchMock;
+
+			const error = await retryClient.fetchPullRequests().catch((e: unknown) => e);
+
+			expect(error).toBeInstanceOf(GitHubApiError);
+			const apiError = error as GitHubApiError;
+			// 403 + X-RateLimit-Remaining: 0 → code は "rate_limited" であること
+			expect(apiError.code).toBe("rate_limited");
+			expect(apiError.statusCode).toBe(403);
+			expect(apiError.rateLimitRemaining).toBe(0);
+		});
+
+		it("should set retryAfter to undefined when Retry-After header is HTTP-date format", async () => {
+			globalThis.fetch = vi.fn().mockResolvedValue({
+				ok: false,
+				status: 429,
+				statusText: "Too Many Requests",
+				headers: new Headers({
+					"Retry-After": "Thu, 01 Jan 2026 00:00:00 GMT",
+					"X-RateLimit-Remaining": "0",
+					"X-RateLimit-Reset": String(Math.floor(Date.now() / 1000) + 60),
+					"X-RateLimit-Limit": "5000",
+				}),
+			});
+
+			const error = await retryClient.fetchPullRequests().catch((e: unknown) => e);
+
+			expect(error).toBeInstanceOf(GitHubApiError);
+			const apiError = error as GitHubApiError;
+			expect(apiError.code).toBe("rate_limited");
+			// HTTP-date 形式は非数値なので retryAfter は undefined
+			expect(apiError.retryAfter).toBeUndefined();
+		});
+
+		it("should retry on 403 with X-RateLimit-Remaining: 0 and Retry-After", async () => {
+			const fetchMock = vi
+				.fn()
+				.mockResolvedValueOnce({
+					ok: false,
+					status: 403,
+					statusText: "Forbidden",
+					headers: new Headers({
+						"Retry-After": "45",
+						"X-RateLimit-Remaining": "0",
+						"X-RateLimit-Reset": String(Math.floor(Date.now() / 1000) + 45),
+						"X-RateLimit-Limit": "5000",
+					}),
+				})
+				.mockResolvedValueOnce({
+					ok: true,
+					json: async () => createSuccessResponse(),
+				});
+			globalThis.fetch = fetchMock;
+
+			const result = await retryClient.fetchPullRequests();
+
+			expect(result.myPrs).toEqual([]);
+			// 403 + X-RateLimit-Remaining: 0 + Retry-After → rate_limited としてリトライ
+			expect(fetchMock).toHaveBeenCalledTimes(2);
 		});
 	});
 });

--- a/src/test/adapter/github/retry.test.ts
+++ b/src/test/adapter/github/retry.test.ts
@@ -65,7 +65,7 @@ describe("withRetry", () => {
 
 		expect(error).toBe(originalError);
 		expect(fn).toHaveBeenCalledTimes(1);
-		expect(shouldRetry).toHaveBeenCalledWith(originalError);
+		expect(shouldRetry).toHaveBeenCalledWith(originalError, 0);
 		expect(delay).not.toHaveBeenCalled();
 	});
 
@@ -152,5 +152,106 @@ describe("withRetry", () => {
 		expect(error).toBe(originalError);
 		expect(fn).toHaveBeenCalledTimes(1);
 		expect(delay).not.toHaveBeenCalled();
+	});
+
+	it("should use getDelayOverride value when it returns a number", async () => {
+		const fn = vi
+			.fn()
+			.mockRejectedValueOnce(new Error("rate limited"))
+			.mockResolvedValue("success");
+		const shouldRetry = vi.fn().mockReturnValue(true);
+		const delay = vi.fn().mockResolvedValue(undefined);
+		const getDelayOverride = vi.fn().mockReturnValue(5000);
+
+		const result = await withRetry(fn, defaultConfig, shouldRetry, delay, {
+			getDelayOverride,
+		});
+
+		expect(result).toBe("success");
+		expect(delay).toHaveBeenCalledTimes(1);
+		// getDelayOverride が 5000 を返したので、exponential backoff (1000) ではなく 5000 が使われる
+		expect(delay).toHaveBeenCalledWith(5000);
+		expect(getDelayOverride).toHaveBeenCalledWith(expect.any(Error));
+	});
+
+	it("should fall back to exponential backoff when getDelayOverride returns undefined", async () => {
+		const fn = vi
+			.fn()
+			.mockRejectedValueOnce(new Error("server error"))
+			.mockResolvedValue("success");
+		const shouldRetry = vi.fn().mockReturnValue(true);
+		const delay = vi.fn().mockResolvedValue(undefined);
+		const getDelayOverride = vi.fn().mockReturnValue(undefined);
+
+		const result = await withRetry(fn, defaultConfig, shouldRetry, delay, {
+			getDelayOverride,
+		});
+
+		expect(result).toBe("success");
+		expect(delay).toHaveBeenCalledTimes(1);
+		// getDelayOverride が undefined を返したので exponential backoff: 1000 * 2^0 = 1000
+		expect(delay).toHaveBeenCalledWith(1000);
+	});
+
+	it("should use getDelayOverride value of 0 when it returns 0", async () => {
+		const fn = vi
+			.fn()
+			.mockRejectedValueOnce(new Error("rate limited"))
+			.mockResolvedValue("success");
+		const shouldRetry = vi.fn().mockReturnValue(true);
+		const delay = vi.fn().mockResolvedValue(undefined);
+		const getDelayOverride = vi.fn().mockReturnValue(0);
+
+		const result = await withRetry(fn, defaultConfig, shouldRetry, delay, {
+			getDelayOverride,
+		});
+
+		expect(result).toBe("success");
+		expect(delay).toHaveBeenCalledTimes(1);
+		// getDelayOverride が 0 を返した場合、delay(0) で即座にリトライ
+		expect(delay).toHaveBeenCalledWith(0);
+		expect(getDelayOverride).toHaveBeenCalledWith(expect.any(Error));
+	});
+
+	it("should not cap getDelayOverride value at maxDelayMs", async () => {
+		const config: RetryConfig = {
+			maxRetries: 3,
+			baseDelayMs: 1000,
+			maxDelayMs: 5000,
+		};
+		const fn = vi
+			.fn()
+			.mockRejectedValueOnce(new Error("rate limited"))
+			.mockResolvedValue("success");
+		const shouldRetry = vi.fn().mockReturnValue(true);
+		const delay = vi.fn().mockResolvedValue(undefined);
+		// Retry-After が maxDelayMs (5000) を大きく超える 30000ms を返す
+		const getDelayOverride = vi.fn().mockReturnValue(30000);
+
+		const result = await withRetry(fn, config, shouldRetry, delay, {
+			getDelayOverride,
+		});
+
+		expect(result).toBe("success");
+		expect(delay).toHaveBeenCalledTimes(1);
+		// レート制限の Retry-After は API 側の指定値を尊重 → maxDelayMs でキャップしない
+		expect(delay).toHaveBeenCalledWith(30000);
+	});
+
+	it("should pass attempt number to shouldRetry", async () => {
+		const fn = vi
+			.fn()
+			.mockRejectedValueOnce(new Error("fail 1"))
+			.mockRejectedValueOnce(new Error("fail 2"))
+			.mockResolvedValue("success");
+		const shouldRetry = vi.fn().mockReturnValue(true);
+		const delay = vi.fn().mockResolvedValue(undefined);
+
+		await withRetry(fn, defaultConfig, shouldRetry, delay);
+
+		// shouldRetry は (error, attempt) で呼ばれる。attempt は 0-indexed
+		expect(shouldRetry).toHaveBeenCalledTimes(2);
+		expect(shouldRetry).toHaveBeenNthCalledWith(1, expect.any(Error), 0);
+		expect(shouldRetry).toHaveBeenNthCalledWith(2, expect.any(Error), 1);
 	});
 });


### PR DESCRIPTION
## 概要

GitHub API の 429 (rate_limited) レスポンスに Retry-After ヘッダーが含まれる場合、指定秒数待機後に1回自動リトライする機能を追加。また 403 + X-RateLimit-Remaining: 0 の secondary rate limit も rate_limited として扱うよう改善。

## 変更内容

- `src/adapter/github/retry.ts`: `withRetry` に `getDelayOverride` オプション引数を追加。`shouldRetry` コールバックに `attempt` 番号を渡す拡張。負値ガード (`Math.max(0, overrideMs)`) 追加
- `src/adapter/github/graphql-client.ts`: `shouldRetryError` に rate_limited 条件追加 (retryAfter > 0 かつ attempt < 1)。`getRateLimitDelay` 関数追加 (Retry-After 秒→ミリ秒変換、120秒キャップ)。`hasValidRetryAfter` 型ガード抽出で DRY 化。403 + X-RateLimit-Remaining: 0 を rate_limited として扱うロジック追加
- `src/test/adapter/github/graphql-client.test.ts`: 429 リトライ成功、429 リトライ上限、403 rate limit 判定、Retry-After 非数値文字列など 12 テストケース追加
- `src/test/adapter/github/retry.test.ts`: getDelayOverride (値/undefined/0/maxDelayMs超過)、attempt 引数渡しの 5 テストケース追加

## 関連 Issue

- closes #92

## テスト

- [ ] TypeScript 型チェック通過 (`pnpm check`)
- [x] フロントエンドテスト通過 (`pnpm test`)
- [ ] Rust lint 通過 (`cargo clippy --all-targets`)
- [ ] Rust テスト通過 (`cargo test`)
- [x] `/verify` で検証ループ PASS

## レビュー観点

- `withRetry` の `getDelayOverride` が `undefined` / `0` / 負値 / maxDelayMs 超過の各パターンで正しく動作するか
- 403 + X-RateLimit-Remaining: 0 の判定ロジックが `extractRateLimitInfo` の null チェックと正しく連携しているか
- rate limit リトライが `attempt < MAX_RATE_LIMIT_RETRIES (=1)` で確実に1回に制限されているか
- `MAX_RETRY_AFTER_MS = 120_000` のキャップ値が Service Worker のライフサイクルに対して妥当か