### PR TITLE
fix: identity.adapter のセキュリティ強化 (verification_uri 検証、エラー情報保持)

### DIFF
--- a/src/adapter/chrome/identity.adapter.ts
+++ b/src/adapter/chrome/identity.adapter.ts
@@ -20,12 +20,19 @@ export class ChromeIdentityAdapter implements AuthPort {
 	private cachedAuthenticated: boolean | null = null;
 	private cachedExpiresAt: number | undefined = undefined;
 	private refreshPromise: Promise<AuthToken | null> | null = null;
+	private disposed = false;
+
+	private readonly storageChangeListener: (
+		changes: Record<string, chrome.storage.StorageChange>,
+		areaName: string,
+	) => void;
 
 	constructor(
 		private readonly storage: StoragePort,
 		private readonly config: OAuthConfig,
 	) {
-		chrome.storage.onChanged.addListener((changes, areaName) => {
+		this.storageChangeListener = (changes, areaName) => {
+			if (this.disposed) return;
 			if (areaName !== "local") return;
 			if (TOKEN_STORAGE_KEY in changes) {
 				const change = changes[TOKEN_STORAGE_KEY];
@@ -37,7 +44,15 @@ export class ChromeIdentityAdapter implements AuthPort {
 					this.cachedExpiresAt = undefined;
 				}
 			}
-		});
+		};
+		chrome.storage.onChanged.addListener(this.storageChangeListener);
+	}
+
+	/** リスナーを解除しリソースを解放する。冪等であり複数回呼んでも安全 */
+	dispose(): void {
+		if (this.disposed) return;
+		this.disposed = true;
+		chrome.storage.onChanged.removeListener(this.storageChangeListener);
 	}
 
 	async requestDeviceCode(): Promise<DeviceCodeResponse> {
@@ -61,7 +76,9 @@ export class ChromeIdentityAdapter implements AuthPort {
 			if (import.meta.env.DEV) {
 				console.error("[identity.adapter] Device code request failed:", error);
 			}
-			throw new AuthError("device_code_request_failed", "Device code request failed");
+			throw new AuthError("device_code_request_failed", "Device code request failed", {
+				cause: error instanceof Error ? new Error(error.message) : new Error(String(error)),
+			});
 		}
 
 		if (!response.ok) {
@@ -102,7 +119,9 @@ export class ChromeIdentityAdapter implements AuthPort {
 			if (import.meta.env.DEV) {
 				console.error("[identity.adapter] Token polling failed:", error);
 			}
-			throw new AuthError("token_exchange_failed", "Token polling failed");
+			throw new AuthError("token_exchange_failed", "Token polling failed", {
+				cause: error instanceof Error ? new Error(error.message) : new Error(String(error)),
+			});
 		}
 
 		if (!response.ok) {
@@ -262,6 +281,12 @@ export class ChromeIdentityAdapter implements AuthPort {
 		}
 		if (typeof data.verification_uri !== "string" || !data.verification_uri) {
 			throw new AuthError("device_code_validation_failed", "Missing verification_uri in response");
+		}
+		if (!data.verification_uri.startsWith("https://github.com/")) {
+			throw new AuthError(
+				"device_code_validation_failed",
+				"Invalid verification_uri: must be a GitHub URL",
+			);
 		}
 		if (typeof data.expires_in !== "number" || data.expires_in <= 0) {
 			throw new AuthError("device_code_validation_failed", "Invalid expires_in in response");

--- a/src/sidepanel/usecase/auth.usecase.ts
+++ b/src/sidepanel/usecase/auth.usecase.ts
@@ -38,7 +38,10 @@ export function createAuthUseCase(sendMessage: SendMessage) {
 				return false;
 			}
 			return response.data.isAuthenticated;
-		} catch {
+		} catch (error) {
+			if (import.meta.env.DEV) {
+				console.error("[auth.usecase] checkAuth failed:", error);
+			}
 			return false;
 		}
 	}

--- a/src/test/adapter/chrome/identity.adapter.test.ts
+++ b/src/test/adapter/chrome/identity.adapter.test.ts
@@ -1109,3 +1109,238 @@ describe("ChromeIdentityAdapter — refreshAccessToken (Issue #57)", () => {
 		expect(fetchMock).not.toHaveBeenCalled();
 	});
 });
+
+// ============================================================
+// Issue #108: verification_uri 検証、cause 保持、dispose()
+// ============================================================
+
+describe("ChromeIdentityAdapter — verification_uri validation (Issue #108)", () => {
+	let adapter: ChromeIdentityAdapter;
+	let mockStorage: ReturnType<typeof createMockStorage>;
+	let originalFetch: typeof globalThis.fetch;
+
+	beforeEach(() => {
+		setupChromeMock();
+		mockStorage = createMockStorage();
+		mockStorage.set.mockResolvedValue(undefined);
+		mockStorage.remove.mockResolvedValue(undefined);
+		adapter = new ChromeIdentityAdapter(mockStorage, TEST_CONFIG);
+		originalFetch = globalThis.fetch;
+	});
+
+	afterEach(() => {
+		resetChromeMock();
+		globalThis.fetch = originalFetch;
+	});
+
+	it("should accept valid verification_uri (https://github.com/login/device)", async () => {
+		globalThis.fetch = vi.fn().mockResolvedValue({
+			ok: true,
+			json: async () => ({
+				device_code: MOCK_DEVICE_CODE_RESPONSE.deviceCode,
+				user_code: MOCK_DEVICE_CODE_RESPONSE.userCode,
+				verification_uri: "https://github.com/login/device",
+				expires_in: MOCK_DEVICE_CODE_RESPONSE.expiresIn,
+				interval: MOCK_DEVICE_CODE_RESPONSE.interval,
+			}),
+		});
+
+		const result = await adapter.requestDeviceCode();
+		expect(result.verificationUri).toBe("https://github.com/login/device");
+	});
+
+	it("should reject verification_uri with userinfo-based URL bypass (github.com@evil.com)", async () => {
+		globalThis.fetch = vi.fn().mockResolvedValue({
+			ok: true,
+			json: async () => ({
+				device_code: MOCK_DEVICE_CODE_RESPONSE.deviceCode,
+				user_code: MOCK_DEVICE_CODE_RESPONSE.userCode,
+				verification_uri: "https://github.com@evil.com/",
+				expires_in: MOCK_DEVICE_CODE_RESPONSE.expiresIn,
+				interval: MOCK_DEVICE_CODE_RESPONSE.interval,
+			}),
+		});
+
+		const error = await adapter.requestDeviceCode().catch((e: unknown) => e);
+		expect(error).toBeInstanceOf(AuthError);
+		expect((error as AuthError).code).toBe("device_code_validation_failed");
+	});
+
+	it("should reject verification_uri pointing to a non-GitHub domain", async () => {
+		globalThis.fetch = vi.fn().mockResolvedValue({
+			ok: true,
+			json: async () => ({
+				device_code: MOCK_DEVICE_CODE_RESPONSE.deviceCode,
+				user_code: MOCK_DEVICE_CODE_RESPONSE.userCode,
+				verification_uri: "https://evil.com/phish",
+				expires_in: MOCK_DEVICE_CODE_RESPONSE.expiresIn,
+				interval: MOCK_DEVICE_CODE_RESPONSE.interval,
+			}),
+		});
+
+		const error = await adapter.requestDeviceCode().catch((e: unknown) => e);
+		expect(error).toBeInstanceOf(AuthError);
+		expect((error as AuthError).code).toBe("device_code_validation_failed");
+	});
+
+	it("should reject verification_uri using HTTP instead of HTTPS", async () => {
+		globalThis.fetch = vi.fn().mockResolvedValue({
+			ok: true,
+			json: async () => ({
+				device_code: MOCK_DEVICE_CODE_RESPONSE.deviceCode,
+				user_code: MOCK_DEVICE_CODE_RESPONSE.userCode,
+				verification_uri: "http://github.com/login/device",
+				expires_in: MOCK_DEVICE_CODE_RESPONSE.expiresIn,
+				interval: MOCK_DEVICE_CODE_RESPONSE.interval,
+			}),
+		});
+
+		const error = await adapter.requestDeviceCode().catch((e: unknown) => e);
+		expect(error).toBeInstanceOf(AuthError);
+		expect((error as AuthError).code).toBe("device_code_validation_failed");
+	});
+
+	it("should reject verification_uri with a spoofed subdomain (github.com.evil.com)", async () => {
+		globalThis.fetch = vi.fn().mockResolvedValue({
+			ok: true,
+			json: async () => ({
+				device_code: MOCK_DEVICE_CODE_RESPONSE.deviceCode,
+				user_code: MOCK_DEVICE_CODE_RESPONSE.userCode,
+				verification_uri: "https://github.com.evil.com/",
+				expires_in: MOCK_DEVICE_CODE_RESPONSE.expiresIn,
+				interval: MOCK_DEVICE_CODE_RESPONSE.interval,
+			}),
+		});
+
+		const error = await adapter.requestDeviceCode().catch((e: unknown) => e);
+		expect(error).toBeInstanceOf(AuthError);
+		expect((error as AuthError).code).toBe("device_code_validation_failed");
+	});
+});
+
+describe("ChromeIdentityAdapter — AuthError cause preservation (Issue #108)", () => {
+	let adapter: ChromeIdentityAdapter;
+	let mockStorage: ReturnType<typeof createMockStorage>;
+	let originalFetch: typeof globalThis.fetch;
+
+	beforeEach(() => {
+		setupChromeMock();
+		mockStorage = createMockStorage();
+		mockStorage.set.mockResolvedValue(undefined);
+		mockStorage.remove.mockResolvedValue(undefined);
+		adapter = new ChromeIdentityAdapter(mockStorage, TEST_CONFIG);
+		originalFetch = globalThis.fetch;
+	});
+
+	afterEach(() => {
+		resetChromeMock();
+		globalThis.fetch = originalFetch;
+	});
+
+	it("should preserve original error as cause when requestDeviceCode fetch rejects", async () => {
+		const originalError = new TypeError("Failed to fetch");
+		globalThis.fetch = vi.fn().mockRejectedValue(originalError);
+
+		const error = await adapter.requestDeviceCode().catch((e: unknown) => e);
+		expect(error).toBeInstanceOf(AuthError);
+		expect((error as AuthError).cause).toBeInstanceOf(Error);
+		expect(((error as AuthError).cause as Error).message).toBe(originalError.message);
+	});
+
+	it("should preserve original error as cause when pollForToken fetch rejects", async () => {
+		const originalError = new TypeError("Network error");
+		globalThis.fetch = vi.fn().mockRejectedValue(originalError);
+
+		const error = await adapter
+			.pollForToken(MOCK_DEVICE_CODE_RESPONSE.deviceCode)
+			.catch((e: unknown) => e);
+		expect(error).toBeInstanceOf(AuthError);
+		expect((error as AuthError).cause).toBeInstanceOf(Error);
+		expect(((error as AuthError).cause as Error).message).toBe(originalError.message);
+	});
+
+	it("should NOT include cause when requestDeviceCode gets HTTP error response (ok: false)", async () => {
+		globalThis.fetch = vi.fn().mockResolvedValue({
+			ok: false,
+			status: 500,
+			statusText: "Internal Server Error",
+		});
+
+		const error = await adapter.requestDeviceCode().catch((e: unknown) => e);
+		expect(error).toBeInstanceOf(AuthError);
+		expect((error as AuthError).code).toBe("device_code_request_failed");
+		expect((error as AuthError).cause).toBeUndefined();
+	});
+
+	it("should NOT include cause when pollForToken gets HTTP error response (ok: false)", async () => {
+		globalThis.fetch = vi.fn().mockResolvedValue({
+			ok: false,
+			status: 500,
+		});
+
+		const error = await adapter
+			.pollForToken(MOCK_DEVICE_CODE_RESPONSE.deviceCode)
+			.catch((e: unknown) => e);
+		expect(error).toBeInstanceOf(AuthError);
+		expect((error as AuthError).code).toBe("token_exchange_failed");
+		expect((error as AuthError).cause).toBeUndefined();
+	});
+});
+
+describe("ChromeIdentityAdapter — dispose() (Issue #108)", () => {
+	let adapter: ChromeIdentityAdapter;
+	let mockStorage: ReturnType<typeof createMockStorage>;
+
+	beforeEach(() => {
+		setupChromeMock();
+		mockStorage = createMockStorage();
+		mockStorage.set.mockResolvedValue(undefined);
+		mockStorage.remove.mockResolvedValue(undefined);
+		adapter = new ChromeIdentityAdapter(mockStorage, TEST_CONFIG);
+	});
+
+	afterEach(() => {
+		resetChromeMock();
+	});
+
+	it("should call chrome.storage.onChanged.removeListener on dispose()", () => {
+		const chromeMock = getChromeMock();
+
+		adapter.dispose();
+
+		expect(chromeMock.storage.onChanged.removeListener).toHaveBeenCalledTimes(1);
+	});
+
+	it("should be idempotent — calling dispose() twice does not throw", () => {
+		adapter.dispose();
+		expect(() => adapter.dispose()).not.toThrow();
+	});
+
+	it("should not update cache after dispose() when storage change fires", async () => {
+		// まずキャッシュを初期化（authenticated = true にする）
+		mockStorage.get.mockResolvedValue(MOCK_TOKEN);
+		await adapter.isAuthenticated();
+
+		const chromeMock = getChromeMock();
+		const listener = chromeMock.storage.onChanged.addListener.mock.calls[0][0] as (
+			changes: Record<string, { oldValue?: unknown; newValue?: unknown }>,
+			areaName: string,
+		) => void;
+
+		// dispose 呼び出し
+		adapter.dispose();
+
+		// dispose 後にストレージ変更を発火（トークン削除）
+		listener({ github_auth_token: { oldValue: MOCK_TOKEN } }, "local");
+
+		// キャッシュが更新されていないことを確認（true のまま）
+		mockStorage.get.mockClear();
+		mockStorage.get.mockImplementation(() => {
+			throw new Error("storage.get should not be called when cache is populated");
+		});
+
+		const result = await adapter.isAuthenticated();
+		expect(result).toBe(true);
+		expect(mockStorage.get).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
## 概要
Issue #68 のレビューで検出された identity.adapter.ts 関連の MEDIUM 指摘4件をまとめて対応。verification_uri のプレフィックス検証、AuthError の cause 保持、checkAuth のサイレントフォールバック改善、リスナー解除メソッド追加を実装。

## 変更内容
- `src/adapter/chrome/identity.adapter.ts`: `validateDeviceCodeData()` に `https://github.com/` プレフィックスチェック追加、`requestDeviceCode()`/`pollForToken()` の catch で `{ cause: new Error(error.message) }` を AuthError に渡すよう変更、`storageChangeListener` をフィールドに保持し `dispose()` メソッドで解除可能に（冪等性あり）
- `src/sidepanel/usecase/auth.usecase.ts`: `checkAuth()` の catch でエラー変数を受け取り DEV モードログ追加
- `src/test/adapter/chrome/identity.adapter.test.ts`: verification_uri 検証（正常系1件+異常系4件）、cause 保持（fetch reject 2件+HTTP エラー2件）、dispose()（removeListener・冪等性・キャッシュ非更新）の計12テスト追加

## 関連 Issue
- closes #108

## テスト
- [x] TypeScript 型チェック通過 (`pnpm check`)
- [x] フロントエンドテスト通過 (`pnpm test`)
- [ ] Rust lint 通過 (`cargo clippy --all-targets`)
- [ ] Rust テスト通過 (`cargo test`)
- [x] `/verify` で検証ループ PASS

## レビュー観点
- `verification_uri` の `startsWith("https://github.com/")` チェックでサブドメインスプーフィング（`github.com.evil.com`）やユーザーインフォバイパス（`github.com@evil.com`）を防げているか
- `cause` に `new Error(error.message)` を渡す設計で、元エラーの内部情報（スタックトレース等）が遮断されているか
- `dispose()` の冪等性（`disposed` フラグ）と、dispose 後のリスナー無効化が正しく機能するか
- レビューで検出されたスコープ外指摘を Issue #114 #115 #116 #117 に分離した判断の妥当性