### PR TITLE
refactor: Device Flow での PKCE/state 不要を ADR で明文化

### DIFF
--- a/.claude/agents/security-reviewer.md
+++ b/.claude/agents/security-reviewer.md
@@ -15,9 +15,9 @@ tools:
 ## チェック観点
 
 ### OAuth / 認証フロー
-- state パラメータによる CSRF 対策
+- state パラメータによる CSRF 対策 (※本プロジェクトは Device Flow のため不要 — ADR-001)
 - redirect_uri の固定
-- PKCE の使用
+- PKCE の使用 (※本プロジェクトは Device Flow のため不要 — ADR-001)
 - token の保存場所が chrome.storage.local に限定されているか
 - token scope が最小限か
 - refresh token のローテーション

--- a/.claude/skills/security-audit/SKILL.md
+++ b/.claude/skills/security-audit/SKILL.md
@@ -11,9 +11,9 @@ $ARGUMENTS の範囲 (未指定ならプロジェクト全体) を `security-rev
 
 1. **シークレット管理** — ハードコードされた token / secret
 2. **入力バリデーション** — ユーザー入力のサニタイズ
-3. **認証フロー** — OAuth state, redirect_uri, PKCE
+3. **認証フロー** — OAuth Device Flow の正しい実装 (PKCE/state は Device Flow では不要 — ADR-001)
 4. **XSS 防止** — `@html`, `innerHTML`, `eval()` の不使用
-5. **CSRF 防止** — state パラメータ、origin 検証
+5. **CSRF 防止** — origin 検証、sender.id チェック (Device Flow のため state パラメータは不要 — ADR-001)
 6. **レート制限** — GitHub API 429 対応、バックオフ戦略
 7. **データ漏洩** — console.log に機密情報がないか
 8. **依存脆弱性** — `pnpm audit`, `cargo audit`
@@ -23,7 +23,7 @@ $ARGUMENTS の範囲 (未指定ならプロジェクト全体) を `security-rev
 ## 自動検出コマンド
 
 ```bash
-grep -rn "ghp_\|gho_\|client_secret\|access_token" src/ rust-core/src/ --include="*.ts" --include="*.rs" --include="*.svelte" || echo "OK"
+grep -rn "ghp_\|gho_\|client_secret\|access_token" src/ rust-core/ --include="*.ts" --include="*.rs" --include="*.svelte" || echo "OK"
 pnpm audit 2>/dev/null || echo "SKIP"
 cd rust-core && cargo audit 2>/dev/null || echo "SKIP"
 ```

--- a/docs/adr/001-device-flow-no-pkce-state.md
+++ b/docs/adr/001-device-flow-no-pkce-state.md
@@ -1,0 +1,30 @@
+# ADR-001: Device Flow では PKCE/state を使用しない
+
+**Status**: Accepted
+**Date**: 2026-03-22
+
+## Context
+
+security.md で PKCE/state が汎用 OAuth のベストプラクティスとして参照されていたが、本プロジェクトは Device Flow (RFC 8628) を採用している。Device Flow にはブラウザリダイレクトが存在しないため、PKCE (RFC 7636) と state パラメータは適用外である。
+
+- PKCE はリダイレクト時の認可コード横取り攻撃を防ぐ仕組みであり、リダイレクトのない Device Flow では攻撃ベクトル自体が存在しない
+- state パラメータは CSRF 対策としてリダイレクト URI に付与するものであり、同様にリダイレクトのない Device Flow では検証先がない
+- 過去に `src/shared/crypto.ts` に `generateState()` / `generateCodeVerifier()` が存在したが、dead code として削除済み
+
+## Decision
+
+Device Flow では PKCE/state を使用しない。セキュリティ監査のチェック観点からも PKCE/state の項目を Device Flow 不要として明記する。
+
+## Consequences
+
+### ポジティブ
+- セキュリティ監査で false positive が発生しなくなる
+- ハーネスのチェック観点と実装が一致する
+- 不要なコード (dead code) が排除された状態を維持できる
+
+### ネガティブ
+- 将来 Authorization Code Flow に変更する場合、本 ADR を Superseded にして PKCE/state を再導入する必要がある
+
+## Alternatives Considered
+
+1. **`requestDeviceCode()` に state パラメータを追加する案** — Device Flow では検証先 (リダイレクト URI) がないため無意味。RFC 8628 にも state の記載なし。プロトコルの誤用になるため却下

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,5 @@
+# Architecture Decision Records
+
+| 番号 | タイトル | ステータス | 日付 |
+|------|---------|-----------|------|
+| 001 | Device Flow では PKCE/state を使用しない | Accepted | 2026-03-22 |


### PR DESCRIPTION
## 概要
Device Flow (RFC 8628) では PKCE/state パラメータが適用外であることを ADR-001 で明文化し、ハーネスのセキュリティチェック観点を Device Flow に合わせて更新した。

## 変更内容
- `docs/adr/001-device-flow-no-pkce-state.md`: ADR-001 を新規作成。Device Flow で PKCE/state が不要である技術的根拠を RFC 参照付きで記録
- `docs/adr/README.md`: ADR インデックスを新規作成
- `.claude/agents/security-reviewer.md`: OAuth チェック観点の state パラメータと PKCE の項目に「Device Flow のため不要 — ADR-001」注記を追加
- `.claude/skills/security-audit/SKILL.md`: 認証フロー・CSRF 防止項目を Device Flow 準拠に更新、自動検出コマンドの grep パスを修正 (`rust-core/src/` → `rust-core/`)

## 関連 Issue
- closes #106

## テスト
- [x] TypeScript 型チェック通過 (`pnpm check`)
- [x] フロントエンドテスト通過 (`pnpm test`)
- [x] Rust lint 通過 (`cargo clippy --all-targets`)
- [x] Rust テスト通過 (`cargo test`)
- [x] `/verify` で検証ループ PASS

## レビュー観点
- ADR-001 の技術的判断が RFC 8628 の仕様と整合しているか
- ハーネスのセキュリティチェック観点の更新により監査精度が低下しないか（state/PKCE の項目は削除せず注記で残す方針）
- 将来 Authorization Code Flow に変更する際の対処が ADR に記載されているか