### PR TITLE
fix: SessionStart hook に gh CLI インストールを追加

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -10,6 +10,9 @@ fi
 
 PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 
+# $HOME/.local/bin を PATH に追加 (gh 等のユーザーローカルバイナリ用)
+export PATH="$HOME/.local/bin:$PATH"
+
 # 必須ツールチェイン確認
 if ! command -v rustup >/dev/null 2>&1 || ! command -v cargo >/dev/null 2>&1; then
   echo "[session-start] ERROR: Rust toolchain (rustup/cargo) not found"
@@ -19,6 +22,21 @@ fi
 if ! command -v pnpm >/dev/null 2>&1; then
   echo "[session-start] ERROR: pnpm not found"
   exit 1
+fi
+
+# GitHub CLI (gh) のインストール (未インストールの場合のみ)
+if ! command -v gh >/dev/null 2>&1; then
+  echo "[session-start] Installing GitHub CLI (gh)..."
+  GH_VERSION="2.65.0"
+  GH_TARBALL="/tmp/gh_${GH_VERSION}_linux_amd64.tar.gz"
+  GH_DIR="/tmp/gh_${GH_VERSION}_linux_amd64"
+  mkdir -p "$HOME/.local/bin"
+  curl -sL "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_amd64.tar.gz" -o "$GH_TARBALL" \
+    && tar xzf "$GH_TARBALL" -C /tmp \
+    && cp "$GH_DIR/bin/gh" "$HOME/.local/bin/gh" \
+    && rm -rf "$GH_TARBALL" "$GH_DIR" \
+    && echo "[session-start] gh $(gh --version | head -1) installed" \
+    || echo "[session-start] WARN: gh installation failed, continuing"
 fi
 
 # cargo-binstall の導入 (未インストールの場合のみ、失敗しても継続)


### PR DESCRIPTION
## 概要

Web 環境のセッション開始時に `gh` CLI が未インストールだった問題を修正。SessionStart hook で自動インストールするようにした。

## 変更内容

- `.claude/hooks/session-start.sh`:
  - スクリプト冒頭で `$HOME/.local/bin` を PATH に追加（ユーザーローカルバイナリの参照を保証）
  - `gh` CLI 未インストール時に GitHub Releases から tarball をダウンロードし `$HOME/.local/bin/gh` に配置する処理を追加
  - インストール失敗時は WARN を出して継続（他ツールと同じポリシー）

## 関連 Issue

N/A（セッション中に gh が見つからず手動インストールが必要になった運用課題の修正）

## テスト

- [x] スクリプトの構文確認（set -euo pipefail 下で問題なし）
- [x] 既に gh がインストール済みの場合はスキップされることを確認
- [ ] Web 環境での実際のセッション開始での動作確認
- [ ] gh インストール後にスキル（`/issue` 等）が正常動作することを確認
- [ ] ネットワーク障害時に WARN で継続することを確認

## レビュー観点

- `GH_VERSION` のハードコードが許容できるか（将来的にバージョン更新が必要）
- `$HOME/.local/bin` への PATH 追加タイミング（冒頭で行うことで gh 以外のローカルバイナリも拾える）
- tarball ダウンロード後の一時ファイルクリーンアップが適切か

https://claude.ai/code/session_01Y8mHDA4sNFrG3Zyj4TfhPa