### PR TITLE
refactor: auth.usecase.ts を src/sidepanel/ から src/shared/ に移動

### DIFF
--- a/.dependency-cruiser.cjs
+++ b/.dependency-cruiser.cjs
@@ -32,6 +32,14 @@ module.exports = {
 			from: { path: "^src/sidepanel/components/" },
 			to: { path: "^src/(adapter|background)/" },
 		},
+		// shared/usecase 層: adapter, background, sidepanel, wasm への依存を禁止
+		// shared/usecase は domain と shared 内の ports/types/config にのみ依存できる
+		{
+			name: "shared-usecase-boundary",
+			severity: "error",
+			from: { path: "^src/shared/usecase/" },
+			to: { path: "^src/(adapter|background|sidepanel|wasm)/" },
+		},
 		// sidepanel/usecase 層: adapter や background への直接依存を禁止
 		// ただし adapter/chrome/message.adapter は正規の通信経路として許可
 		{

--- a/src/shared/usecase/auth.usecase.ts
+++ b/src/shared/usecase/auth.usecase.ts
@@ -1,6 +1,6 @@
 import type { DeviceCodeResponse, PollResult } from "../../domain/types/auth";
-import type { SendMessage } from "../../shared/ports/message.port";
-import type { ResponseMessage } from "../../shared/types/messages";
+import type { SendMessage } from "../ports/message.port";
+import type { ResponseMessage } from "../types/messages";
 
 /** Side Panel 側のポーリング間隔下限 (秒) */
 const MIN_POLL_INTERVAL_SEC = 5;

--- a/src/sidepanel/App.svelte
+++ b/src/sidepanel/App.svelte
@@ -2,7 +2,7 @@
 	import { untrack } from "svelte";
 	import LoginScreen from "./components/LoginScreen.svelte";
 	import MainScreen from "./components/MainScreen.svelte";
-	import type { DeviceFlowState, createAuthUseCase } from "./usecase/auth.usecase.js";
+	import type { DeviceFlowState, createAuthUseCase } from "../shared/usecase/auth.usecase.js";
 
 	type Props = { authUseCase: ReturnType<typeof createAuthUseCase> };
 	const { authUseCase }: Props = $props();

--- a/src/sidepanel/components/LoginScreen.svelte
+++ b/src/sidepanel/components/LoginScreen.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import type { DeviceFlowState } from "../usecase/auth.usecase";
+	import type { DeviceFlowState } from "../../shared/usecase/auth.usecase";
 
 	type Props = {
 		onStartDeviceFlow: () => Promise<{

--- a/src/sidepanel/main.ts
+++ b/src/sidepanel/main.ts
@@ -1,7 +1,7 @@
 import { mount } from "svelte";
 import { chromeSendMessage } from "../adapter/chrome/message.adapter";
+import { createAuthUseCase } from "../shared/usecase/auth.usecase";
 import App from "./App.svelte";
-import { createAuthUseCase } from "./usecase/auth.usecase";
 
 const target = document.getElementById("app");
 if (!target) {

--- a/src/test/architecture/dependency-cruiser.test.ts
+++ b/src/test/architecture/dependency-cruiser.test.ts
@@ -50,11 +50,21 @@ describe("dependency-cruiser アーキテクチャガード", () => {
 		const USECASE_VIOLATION_DIR = resolve(PROJECT_ROOT, "src/sidepanel/usecase/__test_violation__");
 		const USECASE_VIOLATION_FILE = resolve(USECASE_VIOLATION_DIR, "temp_violation.ts");
 
+		const SHARED_USECASE_VIOLATION_DIR = resolve(
+			PROJECT_ROOT,
+			"src/shared/usecase/__test_violation__",
+		);
+		const SHARED_USECASE_VIOLATION_FILE = resolve(
+			SHARED_USECASE_VIOLATION_DIR,
+			"temp_violation.ts",
+		);
+
 		function cleanupViolationDirs(): void {
 			rmSync(DOMAIN_VIOLATION_DIR, { recursive: true, force: true });
 			rmSync(SHARED_VIOLATION_DIR, { recursive: true, force: true });
 			rmSync(ADAPTER_VIOLATION_DIR, { recursive: true, force: true });
 			rmSync(USECASE_VIOLATION_DIR, { recursive: true, force: true });
+			rmSync(SHARED_USECASE_VIOLATION_DIR, { recursive: true, force: true });
 		}
 
 		let depcruiseAvailable = false;
@@ -100,6 +110,14 @@ describe("dependency-cruiser アーキテクチャガード", () => {
 			writeFileSync(
 				USECASE_VIOLATION_FILE,
 				'import { GitHubGraphQLClient } from "../../../adapter/github/graphql-client";\n',
+				"utf-8",
+			);
+
+			// shared/usecase → sidepanel への不正な import
+			mkdirSync(SHARED_USECASE_VIOLATION_DIR, { recursive: true });
+			writeFileSync(
+				SHARED_USECASE_VIOLATION_FILE,
+				'import { something } from "../../../sidepanel/App.svelte";\n',
 				"utf-8",
 			);
 		});
@@ -152,6 +170,10 @@ describe("dependency-cruiser アーキテクチャガード", () => {
 				"sidepanel/usecase→adapter/github",
 			);
 		});
+
+		it("shared/usecase → sidepanel の違反を検出すること", () => {
+			assertViolationDetected("src/shared/usecase/__test_violation__", "shared/usecase→sidepanel");
+		});
 	});
 
 	describe("ルール定義", () => {
@@ -186,6 +208,10 @@ describe("dependency-cruiser アーキテクチャガード", () => {
 
 		it("sidepanel/usecase 層の依存制限ルールが定義されていること", () => {
 			expect(getRuleNames()).toContain("sidepanel-usecase-boundary");
+		});
+
+		it("shared/usecase 層の依存制限ルールが定義されていること", () => {
+			expect(getRuleNames()).toContain("shared-usecase-boundary");
 		});
 	});
 });

--- a/src/test/shared/usecase/auth.usecase.test.ts
+++ b/src/test/shared/usecase/auth.usecase.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { DeviceCodeResponse, PollResult } from "../../../domain/types/auth";
 import type { SendMessage } from "../../../shared/ports/message.port";
 import type { ResponseMessage } from "../../../shared/types/messages";
-import { createAuthUseCase } from "../../../sidepanel/usecase/auth.usecase";
+import { createAuthUseCase } from "../../../shared/usecase/auth.usecase";
 
 describe("auth usecase", () => {
 	let mockSendMessage: ReturnType<typeof vi.fn>;
@@ -396,13 +396,13 @@ describe("auth usecase", () => {
 
 describe("auth.usecase の依存方向", () => {
 	it("DeviceCodeResponse, PollResult を domain/types/auth から直接 import していること", () => {
-		const files = import.meta.glob("../../../sidepanel/usecase/auth.usecase.ts", {
+		const files = import.meta.glob("../../../shared/usecase/auth.usecase.ts", {
 			query: "?raw",
 			eager: true,
 		}) as Record<string, { default: string }>;
 
 		const matchedPaths = Object.keys(files);
-		expect(matchedPaths, "sidepanel/usecase/auth.usecase.ts が見つかりません").toHaveLength(1);
+		expect(matchedPaths, "shared/usecase/auth.usecase.ts が見つかりません").toHaveLength(1);
 
 		const content = Object.values(files)[0]?.default;
 		expect(content).toBeDefined();
@@ -416,14 +416,12 @@ describe("auth.usecase の依存方向", () => {
 	});
 
 	it("shared/types/auth から DeviceCodeResponse, PollResult を import していないこと", () => {
-		const files = import.meta.glob("../../../sidepanel/usecase/auth.usecase.ts", {
+		const files = import.meta.glob("../../../shared/usecase/auth.usecase.ts", {
 			query: "?raw",
 			eager: true,
 		}) as Record<string, { default: string }>;
 
-		expect(Object.keys(files), "sidepanel/usecase/auth.usecase.ts が見つかりません").toHaveLength(
-			1,
-		);
+		expect(Object.keys(files), "shared/usecase/auth.usecase.ts が見つかりません").toHaveLength(1);
 
 		const content = Object.values(files)[0]?.default;
 		expect(content).toBeDefined();


### PR DESCRIPTION
## 概要
「Svelte: UI 表示のみ」の原則に従い、ポーリング制御・リトライロジック・状態遷移を含む `auth.usecase.ts` を `src/sidepanel/usecase/` から `src/shared/usecase/` に移動。dependency-cruiser に `shared/usecase` 境界ルールも追加。

## 変更内容
- `src/sidepanel/usecase/auth.usecase.ts` → `src/shared/usecase/auth.usecase.ts`: ファイル移動 + import パス更新 (`../../shared/ports/` → `../ports/` 等)
- `src/sidepanel/main.ts`: import パスを `../shared/usecase/auth.usecase` に更新
- `src/sidepanel/App.svelte`: import パスを `../shared/usecase/auth.usecase.js` に更新
- `src/sidepanel/components/LoginScreen.svelte`: import パスを `../../shared/usecase/auth.usecase` に更新
- `src/test/sidepanel/usecase/auth.usecase.test.ts` → `src/test/shared/usecase/auth.usecase.test.ts`: テスト移動 + import/glob パス更新
- `.dependency-cruiser.cjs`: `shared-usecase-boundary` ルール追加 (`shared/usecase/` → `adapter/background/sidepanel/wasm` 禁止)
- `src/test/architecture/dependency-cruiser.test.ts`: `shared/usecase → sidepanel` 違反検出テスト + ルール存在確認テスト追加

## 関連 Issue
- closes #114

## テスト
- [x] TypeScript 型チェック通過 (`pnpm check`)
- [x] フロントエンドテスト通過 (`pnpm test`) — 276 tests passed
- [x] Rust lint 通過 (`cargo clippy --all-targets`)
- [x] Rust テスト通過 (`cargo test`)
- [x] `/verify` で検証ループ PASS

## レビュー観点
- `src/shared/usecase/auth.usecase.ts` の import パスが正しく更新されているか (特に `../ports/message.port` と `../types/messages`)
- `import.meta.glob` のパスが `../../../shared/usecase/auth.usecase.ts` に正しく更新されているか (テストファイル 399行目・419行目)
- `.dependency-cruiser.cjs` の `shared-usecase-boundary` ルールが既存パターンと整合しているか