### PR TITLE
fix: identity.adapter.ts から error_description 参照とデッドコードを除去

### DIFF
--- a/src/adapter/chrome/identity.adapter.ts
+++ b/src/adapter/chrome/identity.adapter.ts
@@ -14,9 +14,6 @@ const TOKEN_EXPIRY_BUFFER_MS = 5 * 60 * 1000;
 const DEVICE_CODE_MIN_LENGTH = 8;
 const DEVICE_CODE_MAX_LENGTH = 256;
 
-/** error_description の最大長。過剰な文字列の注入を防ぐ */
-const ERROR_DESCRIPTION_MAX_LENGTH = 500;
-
 /** リフレッシュの最大試行回数 (一時的エラー時のリトライ) */
 const REFRESH_MAX_ATTEMPTS = 3;
 
@@ -155,19 +152,11 @@ export class ChromeIdentityAdapter implements AuthPort {
 					return { status: "expired" };
 				case "access_denied":
 					return { status: "denied" };
-				default: {
-					const raw =
-						typeof data.error_description === "string" && data.error_description.length > 0
-							? data.error_description
-							: data.error;
-					const description = this.sanitizeOAuthErrorMessage(
-						typeof raw === "string" ? raw : String(raw),
-					);
+				default:
 					if (import.meta.env.DEV) {
-						console.warn("[identity.adapter] OAuth error_description:", description);
+						console.warn("[identity.adapter] Unknown OAuth error:", data.error);
 					}
 					throw new AuthError("token_exchange_failed", "Token exchange failed");
-				}
 			}
 		}
 
@@ -465,17 +454,5 @@ export class ChromeIdentityAdapter implements AuthPort {
 			...(typeof data.refresh_token === "string" ? { refreshToken: data.refresh_token } : {}),
 		};
 		return token;
-	}
-
-	/** HTML タグ・制御文字を除去し、長さを制限する */
-	private sanitizeOAuthErrorMessage(raw: string): string {
-		const noHtml = raw.replace(/<[^>]*>/g, "");
-		// 制御文字のうち タブ(0x09)・LF(0x0A) のみ許容する
-		// biome-ignore lint/suspicious/noControlCharactersInRegex: 制御文字除去が目的のため意図的に使用
-		const noControl = noHtml.replace(/[\x00-\x08\x0B-\x1F]/g, "");
-		const trimmed = noControl.trim();
-		return trimmed.length > ERROR_DESCRIPTION_MAX_LENGTH
-			? trimmed.slice(0, ERROR_DESCRIPTION_MAX_LENGTH)
-			: trimmed;
 	}
 }

--- a/src/test/adapter/chrome/identity.adapter.test.ts
+++ b/src/test/adapter/chrome/identity.adapter.test.ts
@@ -468,6 +468,38 @@ describe("ChromeIdentityAdapter — Device Flow", () => {
 				const authError = error as AuthError;
 				expect(authError.message).toBe("Token exchange failed");
 			});
+
+			it("未知エラーの console.warn には error_description が含まれない", async () => {
+				vi.stubEnv("DEV", true);
+
+				const errorDescription = "Sensitive internal details about the failure";
+				globalThis.fetch = vi.fn().mockResolvedValue({
+					ok: true,
+					json: async () => ({
+						error: "unknown_error",
+						error_description: errorDescription,
+					}),
+				});
+
+				const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+				try {
+					await adapter.pollForToken(MOCK_DEVICE_CODE_RESPONSE.deviceCode);
+				} catch {
+					// AuthError が throw されるのは期待通り
+				}
+
+				// DEV モードでは console.warn が必ず呼ばれることを確認
+				expect(warnSpy).toHaveBeenCalled();
+
+				// console.warn の引数に error_description の生の値が含まれないこと
+				for (const call of warnSpy.mock.calls) {
+					const joined = call.map((arg: unknown) => String(arg)).join(" ");
+					expect(joined).not.toContain(errorDescription);
+				}
+
+				warnSpy.mockRestore();
+			});
 		});
 	});
 


### PR DESCRIPTION
## 概要

`identity.adapter.ts` の `sanitizeOAuthErrorMessage` メソッド、`ERROR_DESCRIPTION_MAX_LENGTH` 定数、および `default` ケースの `error_description` 参照を除去し、将来の誤用リスクを排除した。

## 変更内容
- `src/adapter/chrome/identity.adapter.ts`: `ERROR_DESCRIPTION_MAX_LENGTH` 定数を削除、`default` ケースを簡素化（`error_description` 参照を除去し `data.error` のみログ出力）、`sanitizeOAuthErrorMessage` メソッドを削除
- `src/test/adapter/chrome/identity.adapter.test.ts`: 「未知エラーの console.warn には error_description が含まれない」テストを追加（DEV モード有効化 + console.warn 引数検証）

## 関連 Issue
- closes #85

## テスト
- [x] TypeScript 型チェック通過 (`pnpm check`)
- [x] フロントエンドテスト通過 (`pnpm test`) — 309 tests passed
- [ ] Rust lint 通過 (`cargo clippy --all-targets`) — Rust 変更なし
- [x] Rust テスト通過 (`cargo test`)
- [x] `/verify` で検証ループ PASS

## レビュー観点
- `default` ケース (L155-159) で `error_description` を一切参照しなくなったことの確認
- `console.warn` に `data.error`（OAuth エラーコード）のみ出力する設計の妥当性
- 新規テストの `vi.stubEnv("DEV", true)` による DEV モード制御が適切か
- セキュリティレビューで検出した MEDIUM 指摘（LoginScreen.svelte の `e.message` 直接表示）は #130 で別途対応予定