### PR TITLE
refactor: PrItemDto を adapter-wasm crate に移動し domain の WASM 依存を除去

### DIFF
--- a/rust-core/Cargo.lock
+++ b/rust-core/Cargo.lock
@@ -11,6 +11,7 @@ dependencies = [
  "serde",
  "serde-wasm-bindgen",
  "serde_json",
+ "tsify-next",
  "usecase",
  "wasm-bindgen",
  "wasm-bindgen-test",
@@ -78,8 +79,6 @@ version = "0.1.0"
 dependencies = [
  "serde",
  "serde_json",
- "tsify-next",
- "wasm-bindgen",
 ]
 
 [[package]]

--- a/rust-core/crates/adapter-wasm/Cargo.toml
+++ b/rust-core/crates/adapter-wasm/Cargo.toml
@@ -14,6 +14,7 @@ domain = { path = "../domain" }
 usecase = { path = "../usecase" }
 serde = { workspace = true }
 serde_json = "1"
+tsify-next = { workspace = true }
 wasm-bindgen = { workspace = true }
 serde-wasm-bindgen = { workspace = true }
 console_error_panic_hook = { workspace = true }

--- a/rust-core/crates/adapter-wasm/src/dto.rs
+++ b/rust-core/crates/adapter-wasm/src/dto.rs
@@ -1,11 +1,12 @@
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 use tsify_next::Tsify;
 
-use crate::entity::PullRequest;
-use crate::status::{ApprovalStatus, CiStatus};
+use domain::entity::PullRequest;
+use domain::status::{ApprovalStatus, CiStatus};
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Tsify)]
-#[tsify(into_wasm_abi, from_wasm_abi)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Tsify)]
+#[cfg_attr(test, derive(serde::Deserialize))]
+#[tsify(into_wasm_abi)]
 #[serde(rename_all = "camelCase")]
 pub struct PrItemDto {
     pub id: String,
@@ -25,28 +26,44 @@ pub struct PrItemDto {
     pub updated_at: String,
 }
 
-impl From<&PullRequest> for PrItemDto {
-    fn from(pr: &PullRequest) -> Self {
+impl From<PullRequest> for PrItemDto {
+    fn from(pr: PullRequest) -> Self {
+        let (
+            id,
+            number,
+            title,
+            author,
+            url,
+            repository,
+            is_draft,
+            approval_status,
+            ci_status,
+            additions,
+            deletions,
+            created_at,
+            updated_at,
+        ) = pr.into_parts();
         Self {
-            id: pr.id().to_string(),
-            number: pr.number(),
-            title: pr.title().to_string(),
-            author: pr.author().to_string(),
-            url: pr.url().to_string(),
-            repository: pr.repository().to_string(),
-            is_draft: pr.is_draft(),
-            approval_status: pr.approval_status(),
-            ci_status: pr.ci_status(),
-            additions: pr.additions(),
-            deletions: pr.deletions(),
-            created_at: pr.created_at().to_string(),
-            updated_at: pr.updated_at().to_string(),
+            id,
+            number,
+            title,
+            author,
+            url,
+            repository,
+            is_draft,
+            approval_status,
+            ci_status,
+            additions,
+            deletions,
+            created_at,
+            updated_at,
         }
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Tsify)]
-#[tsify(into_wasm_abi, from_wasm_abi)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Tsify)]
+#[cfg_attr(test, derive(serde::Deserialize))]
+#[tsify(into_wasm_abi)]
 #[serde(rename_all = "camelCase")]
 pub struct PrListDto {
     pub items: Vec<PrItemDto>,
@@ -57,8 +74,8 @@ pub struct PrListDto {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::status::{ApprovalStatus, CiStatus};
+    use crate::dto::{PrItemDto, PrListDto};
+    use domain::status::{ApprovalStatus, CiStatus};
 
     fn make_pr_item() -> PrItemDto {
         PrItemDto {
@@ -149,7 +166,7 @@ mod tests {
 
     #[test]
     fn from_pull_request_produces_matching_dto() {
-        use crate::entity::PullRequest;
+        use domain::entity::PullRequest;
 
         let pr = PullRequest::new(
             "PR_456".to_string(),
@@ -168,7 +185,7 @@ mod tests {
         )
         .expect("test PR should be valid");
 
-        let dto = PrItemDto::from(&pr);
+        let dto = PrItemDto::from(pr);
 
         assert_eq!(dto.id, "PR_456");
         assert_eq!(dto.number, 99);
@@ -186,40 +203,62 @@ mod tests {
     }
 
     #[test]
-    fn from_pull_request_with_different_status_variants() {
-        use crate::entity::PullRequest;
+    fn from_pull_request_with_all_status_variants() {
+        use domain::entity::PullRequest;
 
-        let pr = PullRequest::new(
-            "PR_789".to_string(),
-            1,
-            "Fix typo in README".to_string(),
-            "contributor".to_string(),
-            "https://github.com/org/repo/pull/1".to_string(),
-            "org/repo".to_string(),
-            false,
-            ApprovalStatus::Approved,
-            CiStatus::Passed,
-            0,
-            0,
-            "2026-03-20T00:00:00Z".to_string(),
-            "2026-03-21T10:00:00Z".to_string(),
-        )
-        .expect("test PR should be valid");
+        // ApprovalStatus: Approved, ChangesRequested, ReviewRequired, Pending
+        // CiStatus: Passed, Failed, Running, Pending, None
+        // 5 combinations covering every variant at least once
+        let cases: Vec<(ApprovalStatus, CiStatus)> = vec![
+            (ApprovalStatus::Approved, CiStatus::Passed),
+            (ApprovalStatus::ChangesRequested, CiStatus::Failed),
+            (ApprovalStatus::ReviewRequired, CiStatus::Running),
+            (ApprovalStatus::Pending, CiStatus::Pending),
+            (ApprovalStatus::Approved, CiStatus::None),
+        ];
 
-        let dto = PrItemDto::from(&pr);
+        for (i, (approval, ci)) in cases.into_iter().enumerate() {
+            let n = (i + 1) as u32;
+            let pr = PullRequest::new(
+                format!("PR_{n}"),
+                n,
+                format!("PR number {n}"),
+                "author".to_string(),
+                format!("https://github.com/org/repo/pull/{n}"),
+                "org/repo".to_string(),
+                false,
+                approval,
+                ci,
+                10,
+                5,
+                "2026-03-20T00:00:00Z".to_string(),
+                "2026-03-21T10:00:00Z".to_string(),
+            )
+            .expect("test PR should be valid");
 
-        assert_eq!(dto.id, "PR_789");
-        assert_eq!(dto.number, 1);
-        assert_eq!(dto.title, "Fix typo in README");
-        assert_eq!(dto.author, "contributor");
-        assert_eq!(dto.url, "https://github.com/org/repo/pull/1");
-        assert_eq!(dto.repository, "org/repo");
-        assert!(!dto.is_draft);
-        assert_eq!(dto.approval_status, ApprovalStatus::Approved);
-        assert_eq!(dto.ci_status, CiStatus::Passed);
-        assert_eq!(dto.additions, 0);
-        assert_eq!(dto.deletions, 0);
-        assert_eq!(dto.created_at, "2026-03-20T00:00:00Z");
-        assert_eq!(dto.updated_at, "2026-03-21T10:00:00Z");
+            let dto = PrItemDto::from(pr);
+
+            assert_eq!(
+                dto.approval_status, approval,
+                "approval mismatch at index {i}"
+            );
+            assert_eq!(dto.ci_status, ci, "ci mismatch at index {i}");
+            assert_eq!(dto.number, n, "number mismatch at index {i}");
+        }
+    }
+
+    #[test]
+    fn pr_list_dto_total_count_independent_of_items_len() {
+        let item = make_pr_item();
+        let list = PrListDto {
+            items: vec![item],
+            total_count: 42,
+        };
+
+        let json = serde_json::to_string(&list).expect("serialize should succeed");
+        let restored: PrListDto = serde_json::from_str(&json).expect("deserialize should succeed");
+
+        assert_eq!(restored.items.len(), 1);
+        assert_eq!(restored.total_count, 42);
     }
 }

--- a/rust-core/crates/adapter-wasm/src/lib.rs
+++ b/rust-core/crates/adapter-wasm/src/lib.rs
@@ -1,7 +1,8 @@
+pub mod dto;
 pub mod error;
 pub mod parser;
 
-use domain::dto::PrListDto;
+use crate::dto::{PrItemDto, PrListDto};
 use wasm_bindgen::prelude::*;
 
 /// WASM モジュール初期化。パニック時にコンソールにエラーを出力するフックを設定する。
@@ -24,6 +25,12 @@ pub fn greet(name: &str) -> JsValue {
     }
 }
 
+fn to_pr_list_dto(prs: Vec<domain::entity::PullRequest>) -> PrListDto {
+    let total_count = prs.len() as u32;
+    let items = prs.into_iter().map(PrItemDto::from).collect();
+    PrListDto { items, total_count }
+}
+
 /// GraphQL レスポンス JSON を受け取り、分類・ソート済みの PR リストを返す。
 ///
 /// # Arguments
@@ -40,8 +47,8 @@ pub fn process_pull_requests(raw_json: &str, login: &str) -> Result<JsValue, JsE
     let processed = usecase::process::process_pull_requests(login, prs);
 
     serde_wasm_bindgen::to_value(&ProcessedPrsResult {
-        my_prs: processed.my_prs,
-        review_requests: processed.review_requests,
+        my_prs: to_pr_list_dto(processed.my_prs),
+        review_requests: to_pr_list_dto(processed.review_requests),
     })
     .map_err(|e| JsError::new(&e.to_string()))
 }
@@ -99,9 +106,9 @@ mod tests {
 
         let prs = parser::parse_pull_request_nodes(json).expect("should parse");
         let processed = usecase::process::process_pull_requests("alice", prs);
-        assert_eq!(processed.my_prs.items.len(), 1);
-        assert_eq!(processed.my_prs.items[0].number, 1);
-        assert!(processed.review_requests.items.is_empty());
+        assert_eq!(processed.my_prs.len(), 1);
+        assert_eq!(processed.my_prs[0].number(), 1);
+        assert!(processed.review_requests.is_empty());
     }
 
     #[test]
@@ -115,8 +122,8 @@ mod tests {
 
         let prs = parser::parse_pull_request_nodes(json).expect("should parse");
         let processed = usecase::process::process_pull_requests("alice", prs);
-        assert!(processed.my_prs.items.is_empty());
-        assert!(processed.review_requests.items.is_empty());
+        assert!(processed.my_prs.is_empty());
+        assert!(processed.review_requests.is_empty());
     }
 
     #[test]
@@ -172,7 +179,7 @@ mod tests {
 
         let prs = parser::parse_pull_request_nodes(json).expect("should parse");
         let processed = usecase::process::process_pull_requests("alice", prs);
-        assert_eq!(processed.my_prs.items.len(), 1);
-        assert_eq!(processed.review_requests.items.len(), 1);
+        assert_eq!(processed.my_prs.len(), 1);
+        assert_eq!(processed.review_requests.len(), 1);
     }
 }

--- a/rust-core/crates/adapter-wasm/tests/integration.rs
+++ b/rust-core/crates/adapter-wasm/tests/integration.rs
@@ -26,19 +26,19 @@ fn valid_fixture_produces_correct_prs() {
 }
 
 #[test]
-fn valid_fixture_processes_to_classified_dtos() {
+fn valid_fixture_processes_to_classified_lists() {
     let prs = parse_pull_request_nodes(VALID_JSON).expect("valid fixture should parse");
     let processed = usecase::process::process_pull_requests("alice", prs);
 
-    assert_eq!(processed.my_prs.items.len(), 2, "alice has 2 PRs");
-    assert_eq!(processed.review_requests.items.len(), 1, "1 review request");
+    assert_eq!(processed.my_prs.len(), 2, "alice has 2 PRs");
+    assert_eq!(processed.review_requests.len(), 1, "1 review request");
 
     // my_prs sorted by updated_at desc: PR #10 (Jan 5) before PR #11 (Jan 3)
-    assert_eq!(processed.my_prs.items[0].number, 10);
-    assert_eq!(processed.my_prs.items[1].number, 11);
+    assert_eq!(processed.my_prs[0].number(), 10);
+    assert_eq!(processed.my_prs[1].number(), 11);
 
     // review_requests
-    assert_eq!(processed.review_requests.items[0].number, 5);
+    assert_eq!(processed.review_requests[0].number(), 5);
 }
 
 #[test]
@@ -47,10 +47,8 @@ fn empty_fixture_returns_empty_lists() {
     assert!(prs.is_empty());
 
     let processed = usecase::process::process_pull_requests("alice", prs);
-    assert!(processed.my_prs.items.is_empty());
-    assert!(processed.review_requests.items.is_empty());
-    assert_eq!(processed.my_prs.total_count, 0);
-    assert_eq!(processed.review_requests.total_count, 0);
+    assert!(processed.my_prs.is_empty());
+    assert!(processed.review_requests.is_empty());
 }
 
 #[test]

--- a/rust-core/crates/domain/Cargo.toml
+++ b/rust-core/crates/domain/Cargo.toml
@@ -5,11 +5,6 @@ version.workspace = true
 
 [dependencies]
 serde = { workspace = true }
-tsify-next = { workspace = true }
-wasm-bindgen = { workspace = true }
 
 [dev-dependencies]
 serde_json = "1"
-
-[package.metadata.cargo-machete]
-ignored = ["wasm-bindgen"]

--- a/rust-core/crates/domain/src/entity.rs
+++ b/rust-core/crates/domain/src/entity.rs
@@ -168,6 +168,43 @@ impl PullRequest {
     pub fn updated_at(&self) -> &str {
         &self.updated_at
     }
+
+    /// PullRequest を分解してフィールドの所有権を返す。
+    /// adapter 層で不要なアロケーションを避けるために使用する。
+    #[allow(clippy::type_complexity)]
+    pub fn into_parts(
+        self,
+    ) -> (
+        String,
+        u32,
+        String,
+        String,
+        String,
+        String,
+        bool,
+        ApprovalStatus,
+        CiStatus,
+        u32,
+        u32,
+        String,
+        String,
+    ) {
+        (
+            self.id,
+            self.number,
+            self.title,
+            self.author,
+            self.url,
+            self.repository,
+            self.is_draft,
+            self.approval_status,
+            self.ci_status,
+            self.additions,
+            self.deletions,
+            self.created_at,
+            self.updated_at,
+        )
+    }
 }
 
 #[cfg(test)]

--- a/rust-core/crates/domain/src/lib.rs
+++ b/rust-core/crates/domain/src/lib.rs
@@ -1,4 +1,3 @@
-pub mod dto;
 pub mod entity;
 pub mod error;
 pub mod status;

--- a/rust-core/crates/domain/src/status.rs
+++ b/rust-core/crates/domain/src/status.rs
@@ -1,8 +1,6 @@
 use serde::{Deserialize, Serialize};
-use tsify_next::Tsify;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Tsify)]
-#[tsify(into_wasm_abi, from_wasm_abi)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ApprovalStatus {
     /// 少なくとも1人が承認し、変更要求がない状態。
     Approved,
@@ -14,8 +12,7 @@ pub enum ApprovalStatus {
     Pending,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Tsify)]
-#[tsify(into_wasm_abi, from_wasm_abi)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum CiStatus {
     /// 全チェックが成功。
     Passed,

--- a/rust-core/crates/usecase/src/process.rs
+++ b/rust-core/crates/usecase/src/process.rs
@@ -1,12 +1,11 @@
-use domain::dto::{PrItemDto, PrListDto};
 use domain::entity::PullRequest;
 
 use crate::classify::classify_pull_requests;
 use crate::sort::sort_by_updated_at_desc;
 
 pub struct ProcessedPrs {
-    pub my_prs: PrListDto,
-    pub review_requests: PrListDto,
+    pub my_prs: Vec<PullRequest>,
+    pub review_requests: Vec<PullRequest>,
 }
 
 pub fn process_pull_requests(login: &str, pull_requests: Vec<PullRequest>) -> ProcessedPrs {
@@ -15,28 +14,9 @@ pub fn process_pull_requests(login: &str, pull_requests: Vec<PullRequest>) -> Pr
     sort_by_updated_at_desc(&mut classified.my_prs);
     sort_by_updated_at_desc(&mut classified.review_requests);
 
-    let my_items: Vec<PrItemDto> = classified.my_prs.iter().map(PrItemDto::from).collect();
-    let review_items: Vec<PrItemDto> = classified
-        .review_requests
-        .iter()
-        .map(PrItemDto::from)
-        .collect();
-
-    let my_prs = PrListDto {
-        // ページネーション未実装のため items.len() を使用
-        total_count: my_items.len() as u32,
-        items: my_items,
-    };
-
-    let review_requests = PrListDto {
-        // ページネーション未実装のため items.len() を使用
-        total_count: review_items.len() as u32,
-        items: review_items,
-    };
-
     ProcessedPrs {
-        my_prs,
-        review_requests,
+        my_prs: classified.my_prs,
+        review_requests: classified.review_requests,
     }
 }
 
@@ -73,24 +53,22 @@ mod tests {
         ];
         let result = process_pull_requests("alice", prs);
 
-        assert_eq!(result.my_prs.items.len(), 2);
-        assert_eq!(result.review_requests.items.len(), 1);
+        assert_eq!(result.my_prs.len(), 2);
+        assert_eq!(result.review_requests.len(), 1);
 
         // my_prs should be sorted by updated_at desc
-        assert_eq!(result.my_prs.items[0].number, 3);
-        assert_eq!(result.my_prs.items[1].number, 1);
+        assert_eq!(result.my_prs[0].number(), 3);
+        assert_eq!(result.my_prs[1].number(), 1);
 
         // review_requests
-        assert_eq!(result.review_requests.items[0].number, 2);
+        assert_eq!(result.review_requests[0].number(), 2);
     }
 
     #[test]
-    fn process_empty_list_returns_empty_dtos() {
+    fn process_empty_list_returns_empty() {
         let result = process_pull_requests("alice", vec![]);
-        assert!(result.my_prs.items.is_empty());
-        assert_eq!(result.my_prs.total_count, 0);
-        assert!(result.review_requests.items.is_empty());
-        assert_eq!(result.review_requests.total_count, 0);
+        assert!(result.my_prs.is_empty());
+        assert!(result.review_requests.is_empty());
     }
 
     #[test]
@@ -100,9 +78,8 @@ mod tests {
             make_pr("alice", 2, "2026-01-02T00:00:00Z"),
         ];
         let result = process_pull_requests("alice", prs);
-        assert_eq!(result.my_prs.items.len(), 2);
-        assert!(result.review_requests.items.is_empty());
-        assert_eq!(result.review_requests.total_count, 0);
+        assert_eq!(result.my_prs.len(), 2);
+        assert!(result.review_requests.is_empty());
     }
 
     #[test]
@@ -112,9 +89,8 @@ mod tests {
             make_pr("charlie", 2, "2026-01-02T00:00:00Z"),
         ];
         let result = process_pull_requests("alice", prs);
-        assert!(result.my_prs.items.is_empty());
-        assert_eq!(result.my_prs.total_count, 0);
-        assert_eq!(result.review_requests.items.len(), 2);
+        assert!(result.my_prs.is_empty());
+        assert_eq!(result.review_requests.len(), 2);
     }
 
     #[test]
@@ -125,40 +101,23 @@ mod tests {
             make_pr("dave", 3, "2026-01-02T00:00:00Z"),
         ];
         let result = process_pull_requests("alice", prs);
-        assert_eq!(result.review_requests.items.len(), 3);
-        assert_eq!(result.review_requests.items[0].number, 2);
-        assert_eq!(result.review_requests.items[1].number, 3);
-        assert_eq!(result.review_requests.items[2].number, 1);
-    }
-
-    /// ページネーション未実装時点では total_count == items.len()。
-    /// ページネーション導入時にはこのテストの更新が必要。
-    #[test]
-    fn total_count_matches_items_len() {
-        let prs = vec![
-            make_pr("alice", 1, "2026-01-01T00:00:00Z"),
-            make_pr("bob", 2, "2026-01-02T00:00:00Z"),
-            make_pr("alice", 3, "2026-01-03T00:00:00Z"),
-        ];
-        let result = process_pull_requests("alice", prs);
-        assert_eq!(result.my_prs.total_count, result.my_prs.items.len() as u32);
-        assert_eq!(
-            result.review_requests.total_count,
-            result.review_requests.items.len() as u32
-        );
+        assert_eq!(result.review_requests.len(), 3);
+        assert_eq!(result.review_requests[0].number(), 2);
+        assert_eq!(result.review_requests[1].number(), 3);
+        assert_eq!(result.review_requests[2].number(), 1);
     }
 
     #[test]
-    fn dto_fields_match_original_pull_request() {
+    fn pr_fields_preserved_after_processing() {
         let prs = vec![make_pr("alice", 42, "2026-01-15T12:00:00Z")];
         let result = process_pull_requests("alice", prs);
-        let dto = &result.my_prs.items[0];
-        assert_eq!(dto.number, 42);
-        assert_eq!(dto.author, "alice");
-        assert_eq!(dto.title, "PR #42");
-        assert_eq!(dto.repository, "owner/repo");
-        assert_eq!(dto.additions, 10);
-        assert_eq!(dto.deletions, 5);
-        assert_eq!(dto.updated_at, "2026-01-15T12:00:00Z");
+        let pr = &result.my_prs[0];
+        assert_eq!(pr.number(), 42);
+        assert_eq!(pr.author(), "alice");
+        assert_eq!(pr.title(), "PR #42");
+        assert_eq!(pr.repository(), "owner/repo");
+        assert_eq!(pr.additions(), 10);
+        assert_eq!(pr.deletions(), 5);
+        assert_eq!(pr.updated_at(), "2026-01-15T12:00:00Z");
     }
 }


### PR DESCRIPTION
## 概要
domain crate が `tsify-next` / `wasm-bindgen` に依存しており、「domain crate は依存なし」というアーキテクチャルールと矛盾していた。`PrItemDto`/`PrListDto` とその `From` 実装を `adapter-wasm` crate に移動し、usecase の戻り値を `Vec<PullRequest>` に変更することで依存を正しく整理した。

## 変更内容
- `rust-core/crates/domain/src/dto.rs`: 削除 → `adapter-wasm/src/dto.rs` に移動
- `rust-core/crates/adapter-wasm/src/dto.rs`: `PrItemDto`/`PrListDto` 定義、`From<PullRequest>` 実装、テスト（新規）
- `rust-core/crates/adapter-wasm/src/lib.rs`: `to_pr_list_dto` ヘルパー追加、DTO 変換を adapter-wasm 側で実行
- `rust-core/crates/adapter-wasm/Cargo.toml`: `tsify-next` 依存を追加
- `rust-core/crates/adapter-wasm/tests/integration.rs`: `Vec<PullRequest>` API に合わせてアサーション修正
- `rust-core/crates/domain/Cargo.toml`: `tsify-next`/`wasm-bindgen` 依存と `cargo-machete` ignored を削除
- `rust-core/crates/domain/src/lib.rs`: `pub mod dto;` を削除
- `rust-core/crates/domain/src/status.rs`: `Tsify` derive と `tsify` attribute を削除
- `rust-core/crates/domain/src/entity.rs`: `into_parts()` メソッドを追加（所有権版 From 変換用）
- `rust-core/crates/usecase/src/process.rs`: `ProcessedPrs` の型を `PrListDto` → `Vec<PullRequest>` に変更、DTO 変換ロジックを削除

## 関連 Issue
- closes #102

## テスト
- [x] TypeScript 型チェック通過 (`pnpm check`)
- [x] フロントエンドテスト通過 (`pnpm test`)
- [x] Rust lint 通過 (`cargo clippy --all-targets`)
- [x] Rust テスト通過 (`cargo test`)
- [x] `/verify` で検証ループ PASS

## レビュー観点
- domain crate から `tsify-next`/`wasm-bindgen` 依存が完全に除去されているか
- `PrItemDto` の `Deserialize` がテスト時のみ (`#[cfg_attr(test, ...)]`) であること
- usecase が DTO を知らず、`Vec<PullRequest>` のみを返す設計になっているか
- `into_parts()` による所有権ムーブが適切か