### PR TITLE
feat: ChromeIdentityAdapter.dispose() の呼び出し元を実装

### DIFF
--- a/src/background/bootstrap.ts
+++ b/src/background/bootstrap.ts
@@ -25,5 +25,16 @@ export function initializeApp(): AppServices {
 	const handler = createMessageHandler({ auth, githubApi });
 	chrome.runtime.onMessage.addListener(handler);
 
-	return { auth, githubApi };
+	let disposed = false;
+	const dispose = (): void => {
+		if (disposed) return;
+		disposed = true;
+		try {
+			auth.dispose();
+		} finally {
+			chrome.runtime.onMessage.removeListener(handler);
+		}
+	};
+
+	return { auth, githubApi, dispose };
 }

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -1,6 +1,10 @@
 import { initializeApp } from "./bootstrap";
 
-initializeApp();
+const services = initializeApp();
+
+chrome.runtime.onSuspend.addListener(() => {
+	services.dispose();
+});
 
 chrome.sidePanel
 	.setPanelBehavior({ openPanelOnActionClick: true })

--- a/src/background/message-handler.ts
+++ b/src/background/message-handler.ts
@@ -15,7 +15,7 @@ const ERROR_MESSAGES: Record<MessageType, string> = {
 const DEVICE_CODE_MIN_LENGTH = 8;
 const DEVICE_CODE_MAX_LENGTH = 256;
 
-export function createMessageHandler(services: AppServices) {
+export function createMessageHandler(services: Pick<AppServices, "auth" | "githubApi">) {
 	return (
 		message: unknown,
 		sender: chrome.runtime.MessageSender,
@@ -36,7 +36,7 @@ export function createMessageHandler(services: AppServices) {
 }
 
 async function handleMessage(
-	services: AppServices,
+	services: Pick<AppServices, "auth" | "githubApi">,
 	message: RequestMessage<MessageType>,
 	sendResponse: (response: ResponseMessage<MessageType>) => void,
 ): Promise<void> {

--- a/src/background/types.ts
+++ b/src/background/types.ts
@@ -4,4 +4,5 @@ import type { GitHubApiPort } from "../domain/ports/github-api.port";
 export type AppServices = {
 	readonly auth: AuthPort;
 	readonly githubApi: GitHubApiPort;
+	readonly dispose: () => void;
 };

--- a/src/test/background/bootstrap.test.ts
+++ b/src/test/background/bootstrap.test.ts
@@ -29,4 +29,36 @@ describe("bootstrap", () => {
 			expect(chrome.runtime.onMessage.addListener).toHaveBeenCalledWith(expect.any(Function));
 		});
 	});
+
+	describe("dispose (Issue #115)", () => {
+		it("should return AppServices with dispose function", () => {
+			const services = initializeApp();
+			expect(services).toHaveProperty("dispose");
+			expect(typeof services.dispose).toBe("function");
+		});
+
+		it("should call chrome.storage.onChanged.removeListener with the registered listener on dispose", () => {
+			const services = initializeApp();
+			const addedListener = vi.mocked(chrome.storage.onChanged.addListener).mock.calls[0]?.[0];
+			expect(addedListener).toBeDefined();
+			services.dispose();
+			expect(chrome.storage.onChanged.removeListener).toHaveBeenCalledWith(addedListener);
+		});
+
+		it("should call chrome.runtime.onMessage.removeListener with the registered handler on dispose", () => {
+			const services = initializeApp();
+			const registeredHandler = vi.mocked(chrome.runtime.onMessage.addListener).mock.calls[0]?.[0];
+			expect(registeredHandler).toBeDefined();
+			services.dispose();
+			expect(chrome.runtime.onMessage.removeListener).toHaveBeenCalledWith(registeredHandler);
+		});
+
+		it("should not throw when dispose is called twice (idempotent)", () => {
+			const services = initializeApp();
+			services.dispose();
+			expect(() => services.dispose()).not.toThrow();
+			expect(chrome.storage.onChanged.removeListener).toHaveBeenCalledTimes(1);
+			expect(chrome.runtime.onMessage.removeListener).toHaveBeenCalledTimes(1);
+		});
+	});
 });

--- a/src/test/mocks/chrome.mock.ts
+++ b/src/test/mocks/chrome.mock.ts
@@ -23,6 +23,10 @@ type ChromeMock = {
 			addListener: ReturnType<typeof vi.fn>;
 			removeListener: ReturnType<typeof vi.fn>;
 		};
+		onSuspend: {
+			addListener: ReturnType<typeof vi.fn>;
+			removeListener: ReturnType<typeof vi.fn>;
+		};
 		lastError: chrome.runtime.LastError | undefined;
 	};
 };
@@ -50,6 +54,10 @@ function createChromeMock(): ChromeMock {
 			id: "test-extension-id",
 			sendMessage: vi.fn(),
 			onMessage: {
+				addListener: vi.fn(),
+				removeListener: vi.fn(),
+			},
+			onSuspend: {
 				addListener: vi.fn(),
 				removeListener: vi.fn(),
 			},


### PR DESCRIPTION
## 概要
Service Worker の `chrome.runtime.onSuspend` イベントで `ChromeIdentityAdapter.dispose()` を呼び出し、`chrome.storage.onChanged` リスナーと `onMessage` ハンドラを適切に解除するライフサイクル管理を実装した。

## 変更内容
- `src/background/types.ts`: `AppServices` 型に `readonly dispose: () => void` を追加
- `src/background/bootstrap.ts`: Composition Root で dispose 関数を組み立て（auth.dispose() + onMessage リスナー解除、try-finally で例外安全、冪等性ガード付き）
- `src/background/index.ts`: `chrome.runtime.onSuspend` リスナーで `services.dispose()` を呼び出し
- `src/background/message-handler.ts`: `createMessageHandler` の引数型を `Pick<AppServices, "auth" | "githubApi">` に絞り込み（dispose を不要な依存から除外）
- `src/test/background/bootstrap.test.ts`: dispose 関連テスト 4件追加（存在確認・storage リスナー解除・onMessage 解除・冪等性）
- `src/test/mocks/chrome.mock.ts`: `chrome.runtime.onSuspend` の mock を追加

## 関連 Issue
- closes #115
- refs #137 (AuthPort への Disposable インターフェース導入検討 — スコープ外として Issue 化)

## テスト
- [x] TypeScript 型チェック通過 (`pnpm check`)
- [x] フロントエンドテスト通過 (`pnpm test`) — 312 tests passed
- [x] Rust lint 通過 (`cargo clippy --all-targets`)
- [x] Rust テスト通過 (`cargo test`)
- [x] `/verify` で検証ループ PASS

## レビュー観点
- `bootstrap.ts` の dispose 関数: try-finally による例外安全性と冪等性ガードが適切か
- `message-handler.ts` の `Pick<AppServices, ...>` 型絞り込みが既存テストを壊していないか
- `onSuspend` が Service Worker ライフサイクルとして適切なタイミングか