### PR TITLE
refactor: Device Flow状態管理ロジックをSvelteコンポーネントから分離

### DIFF
--- a/src/shared/usecase/device-flow.controller.ts
+++ b/src/shared/usecase/device-flow.controller.ts
@@ -1,0 +1,100 @@
+import type { DeviceFlowState, createAuthUseCase } from "./auth.usecase";
+
+export type DeviceFlowController = {
+	readonly getState: () => DeviceFlowState;
+	readonly startFlow: () => Promise<void>;
+	readonly waitForAuthorization: () => Promise<void>;
+	readonly startAndWait: () => Promise<void>;
+	readonly subscribe: (listener: (state: DeviceFlowState) => void) => () => void;
+};
+
+type PendingRequest = {
+	readonly deviceCode: string;
+	readonly interval: number;
+	readonly expiresIn: number;
+};
+
+export function createDeviceFlowController(
+	authUseCase: Pick<
+		ReturnType<typeof createAuthUseCase>,
+		"requestDeviceCode" | "waitForAuthorization"
+	>,
+): DeviceFlowController {
+	let state: DeviceFlowState = { phase: "idle" };
+	let pendingRequest: PendingRequest | undefined;
+	const listeners = new Set<(state: DeviceFlowState) => void>();
+
+	function setState(newState: DeviceFlowState): void {
+		state = newState;
+		for (const listener of listeners) {
+			listener(state);
+		}
+	}
+
+	async function startFlow(): Promise<void> {
+		try {
+			const result = await authUseCase.requestDeviceCode();
+			pendingRequest = {
+				deviceCode: result.deviceCode,
+				interval: result.interval,
+				expiresIn: result.expiresIn,
+			};
+			setState({
+				phase: "awaiting_user",
+				userCode: result.userCode,
+				verificationUri: result.verificationUri,
+			});
+		} catch (error: unknown) {
+			const message = error instanceof Error ? error.message : String(error);
+			setState({ phase: "error", message });
+		}
+	}
+
+	async function waitForAuthorization(): Promise<void> {
+		if (pendingRequest === undefined) {
+			throw new Error("Device code not available");
+		}
+
+		try {
+			await authUseCase.waitForAuthorization(
+				pendingRequest.deviceCode,
+				pendingRequest.interval,
+				pendingRequest.expiresIn,
+				(newState) => {
+					setState(newState);
+				},
+			);
+		} catch (error: unknown) {
+			const current = state;
+			if (current.phase !== "error" && current.phase !== "expired" && current.phase !== "denied") {
+				const message = error instanceof Error ? error.message : String(error);
+				setState({ phase: "error", message });
+			}
+		}
+	}
+
+	async function startAndWait(): Promise<void> {
+		await startFlow();
+
+		if (state.phase !== "awaiting_user") {
+			return;
+		}
+
+		await waitForAuthorization();
+	}
+
+	function subscribe(listener: (state: DeviceFlowState) => void): () => void {
+		listeners.add(listener);
+		return () => {
+			listeners.delete(listener);
+		};
+	}
+
+	return {
+		getState: () => state,
+		startFlow,
+		waitForAuthorization,
+		startAndWait,
+		subscribe,
+	};
+}

--- a/src/sidepanel/App.svelte
+++ b/src/sidepanel/App.svelte
@@ -2,22 +2,19 @@
 	import { untrack } from "svelte";
 	import LoginScreen from "./components/LoginScreen.svelte";
 	import MainScreen from "./components/MainScreen.svelte";
-	import type { DeviceFlowState, createAuthUseCase } from "../shared/usecase/auth.usecase.js";
+	import type { createAuthUseCase } from "../shared/usecase/auth.usecase.js";
 	import type { createPrUseCase } from "../shared/usecase/pr.usecase.js";
+	import type { DeviceFlowController } from "../shared/usecase/device-flow.controller.js";
 
 	type Props = {
-		authUseCase: ReturnType<typeof createAuthUseCase>;
+		authUseCase: Pick<ReturnType<typeof createAuthUseCase>, "checkAuth" | "logout">;
 		prUseCase: ReturnType<typeof createPrUseCase>;
+		deviceFlowController: DeviceFlowController;
 	};
-	const { authUseCase, prUseCase }: Props = $props();
+	const { authUseCase, prUseCase, deviceFlowController }: Props = $props();
 
 	let authenticated = $state(false);
 	let loading = $state(true);
-
-	/** Device Flow 開始時に取得した情報を保持する */
-	let pendingDeviceCode = $state<string | null>(null);
-	let pendingInterval = $state(5);
-	let pendingExpiresIn = $state(900);
 
 	$effect(() => {
 		let cancelled = false;
@@ -35,34 +32,13 @@
 		};
 	});
 
-	async function handleStartDeviceFlow(): Promise<{
-		userCode: string;
-		verificationUri: string;
-	}> {
-		const result = await authUseCase.requestDeviceCode();
-		pendingDeviceCode = result.deviceCode;
-		pendingInterval = result.interval;
-		pendingExpiresIn = result.expiresIn;
-		return {
-			userCode: result.userCode,
-			verificationUri: result.verificationUri,
-		};
-	}
-
-	async function handleWaitForAuthorization(
-		onStateChange: (state: DeviceFlowState) => void,
-	): Promise<void> {
-		if (!pendingDeviceCode) {
-			throw new Error("No pending device code");
-		}
-		await authUseCase.waitForAuthorization(
-			pendingDeviceCode,
-			pendingInterval,
-			pendingExpiresIn,
-			onStateChange,
-		);
-		authenticated = true;
-	}
+	$effect(() => {
+		return deviceFlowController.subscribe((state) => {
+			if (state.phase === "success") {
+				authenticated = true;
+			}
+		});
+	});
 
 	async function handleLogout(): Promise<void> {
 		await authUseCase.logout();
@@ -75,8 +51,5 @@
 {:else if authenticated}
 	<MainScreen onLogout={handleLogout} fetchPrs={() => prUseCase.fetchPrs("@me")} />
 {:else}
-	<LoginScreen
-		onStartDeviceFlow={handleStartDeviceFlow}
-		onWaitForAuthorization={handleWaitForAuthorization}
-	/>
+	<LoginScreen controller={deviceFlowController} />
 {/if}

--- a/src/sidepanel/components/LoginScreen.svelte
+++ b/src/sidepanel/components/LoginScreen.svelte
@@ -1,55 +1,47 @@
 <script lang="ts">
 	import type { DeviceFlowState } from "../../shared/usecase/auth.usecase";
+	import type { DeviceFlowController } from "../../shared/usecase/device-flow.controller";
 
 	type Props = {
-		onStartDeviceFlow: () => Promise<{
-			userCode: string;
-			verificationUri: string;
-		}>;
-		onWaitForAuthorization: (onStateChange: (state: DeviceFlowState) => void) => Promise<void>;
+		controller: DeviceFlowController;
 	};
 
-	const { onStartDeviceFlow, onWaitForAuthorization }: Props = $props();
+	const { controller }: Props = $props();
 
-	let flowState = $state<DeviceFlowState>({ phase: "idle" });
-	let userCode = $state("");
-	let verificationUri = $state("");
-	let error = $state<string | null>(null);
+	let flowState = $state<DeviceFlowState>(controller.getState());
+	let inProgress = $state(false);
+	let lastUserCode = $state<string | null>(null);
+
+	$effect(() => {
+		return controller.subscribe((state) => {
+			flowState = state;
+			if (state.phase === "awaiting_user") {
+				lastUserCode = state.userCode;
+			}
+		});
+	});
 
 	async function handleStartFlow() {
-		error = null;
-		flowState = { phase: "idle" };
+		if (inProgress) return;
+		inProgress = true;
 
 		try {
-			const deviceCode = await onStartDeviceFlow();
-			userCode = deviceCode.userCode;
-			verificationUri = deviceCode.verificationUri;
-			flowState = {
-				phase: "awaiting_user",
-				userCode: deviceCode.userCode,
-				verificationUri: deviceCode.verificationUri,
-			};
-
-			await onWaitForAuthorization((state) => {
-				flowState = state;
-			});
-		} catch (e: unknown) {
-			error = e instanceof Error ? e.message : "Unknown error";
-			// onStateChange コールバック経由で expired/denied に遷移済みの場合はそのまま維持
-			const phase = (flowState as { phase: string }).phase;
-			if (phase !== "expired" && phase !== "denied") {
-				flowState = { phase: "error", message: error };
-			}
+			await controller.startAndWait();
+		} finally {
+			inProgress = false;
 		}
 	}
 
 	function handleCopyCode() {
-		navigator.clipboard.writeText(userCode);
+		if (lastUserCode !== null) {
+			navigator.clipboard.writeText(lastUserCode);
+		}
 	}
 
 	function openVerificationUri() {
-		if (!verificationUri.startsWith("https://")) return;
-		window.open(verificationUri, "_blank");
+		if (flowState.phase === "awaiting_user" && flowState.verificationUri.startsWith("https://")) {
+			window.open(flowState.verificationUri, "_blank");
+		}
 	}
 </script>
 
@@ -59,12 +51,12 @@
 	{#if flowState.phase === "idle" || flowState.phase === "error" || flowState.phase === "expired" || flowState.phase === "denied"}
 		<p>PR Sidebar を利用するには GitHub アカウントでログインしてください。</p>
 
-		<button class="login-btn" onclick={handleStartFlow}>
+		<button class="login-btn" disabled={inProgress} onclick={handleStartFlow}>
 			Login with GitHub
 		</button>
 
-		{#if error}
-			<p class="error">{error}</p>
+		{#if flowState.phase === "error"}
+			<p class="error">{flowState.message}</p>
 		{/if}
 	{/if}
 
@@ -73,17 +65,19 @@
 			<p class="instruction">以下のコードを GitHub に入力してください:</p>
 
 			<div class="user-code-container">
-				<code class="user-code">{userCode}</code>
+				<code class="user-code">{flowState.phase === "awaiting_user" ? flowState.userCode : lastUserCode ?? ""}</code>
 				<button class="copy-btn" onclick={handleCopyCode}>Copy</button>
 			</div>
 
-			<a
-				class="verification-link"
-				href={verificationUri}
-				onclick={(e) => { e.preventDefault(); openVerificationUri(); }}
-			>
-				{verificationUri} を開く
-			</a>
+			{#if flowState.phase === "awaiting_user"}
+				<a
+					class="verification-link"
+					href={flowState.verificationUri}
+					onclick={(e) => { e.preventDefault(); openVerificationUri(); }}
+				>
+					{flowState.verificationUri} を開く
+				</a>
+			{/if}
 
 			<p class="polling-status">認証待ち...</p>
 		</div>

--- a/src/sidepanel/main.ts
+++ b/src/sidepanel/main.ts
@@ -1,6 +1,7 @@
 import { mount } from "svelte";
 import { chromeSendMessage } from "../adapter/chrome/message.adapter";
 import { createAuthUseCase } from "../shared/usecase/auth.usecase";
+import { createDeviceFlowController } from "../shared/usecase/device-flow.controller";
 import { createPrUseCase } from "../shared/usecase/pr.usecase";
 import { WasmPrProcessor } from "../wasm/pr-processor";
 import App from "./App.svelte";
@@ -11,9 +12,10 @@ if (!target) {
 }
 
 const authUseCase = createAuthUseCase(chromeSendMessage);
+const deviceFlowController = createDeviceFlowController(authUseCase);
 const prProcessor = new WasmPrProcessor();
 const prUseCase = createPrUseCase(chromeSendMessage, prProcessor);
 
-const app = mount(App, { target, props: { authUseCase, prUseCase } });
+const app = mount(App, { target, props: { authUseCase, prUseCase, deviceFlowController } });
 
 export default app;

--- a/src/test/shared/usecase/device-flow.controller.test.ts
+++ b/src/test/shared/usecase/device-flow.controller.test.ts
@@ -1,0 +1,308 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { DeviceCodeResponse, PollResult } from "../../../domain/types/auth";
+import type { DeviceFlowState } from "../../../shared/usecase/auth.usecase";
+import { createDeviceFlowController } from "../../../shared/usecase/device-flow.controller";
+
+describe("device-flow controller", () => {
+	let mockRequestDeviceCode: ReturnType<typeof vi.fn>;
+	let mockWaitForAuthorization: ReturnType<typeof vi.fn>;
+
+	function buildController() {
+		return createDeviceFlowController({
+			requestDeviceCode: mockRequestDeviceCode,
+			waitForAuthorization: mockWaitForAuthorization,
+		});
+	}
+
+	const deviceCodeResponse: DeviceCodeResponse = {
+		deviceCode: "dc-abc123",
+		userCode: "ABCD-1234",
+		verificationUri: "https://github.com/login/device",
+		expiresIn: 900,
+		interval: 5,
+	};
+
+	beforeEach(() => {
+		mockRequestDeviceCode = vi.fn();
+		mockWaitForAuthorization = vi.fn();
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("startFlow() が requestDeviceCode を呼び、state を awaiting_user に遷移させること", async () => {
+		mockRequestDeviceCode.mockResolvedValue(deviceCodeResponse);
+		// waitForAuthorization は startFlow 内では呼ばれない想定だが、
+		// 実装によっては呼ばれうるので pending な Promise を返す
+		mockWaitForAuthorization.mockReturnValue(new Promise(() => {}));
+
+		const controller = buildController();
+
+		expect(controller.getState()).toEqual({ phase: "idle" });
+
+		await controller.startFlow();
+
+		expect(mockRequestDeviceCode).toHaveBeenCalledOnce();
+		expect(mockWaitForAuthorization).not.toHaveBeenCalled();
+		const state = controller.getState();
+		expect(state.phase).toBe("awaiting_user");
+		if (state.phase === "awaiting_user") {
+			expect(state.userCode).toBe("ABCD-1234");
+			expect(state.verificationUri).toBe("https://github.com/login/device");
+		}
+	});
+
+	it("startFlow() 失敗時に state が error になること", async () => {
+		mockRequestDeviceCode.mockRejectedValue(new Error("Network failure"));
+
+		const controller = buildController();
+
+		await controller.startFlow();
+
+		const state = controller.getState();
+		expect(state.phase).toBe("error");
+		if (state.phase === "error") {
+			expect(state.message).toBe("Network failure");
+		}
+	});
+
+	it("waitForAuthorization() が保持された deviceCode で authUseCase.waitForAuthorization を呼ぶこと", async () => {
+		mockRequestDeviceCode.mockResolvedValue(deviceCodeResponse);
+		mockWaitForAuthorization.mockResolvedValue(undefined);
+
+		const controller = buildController();
+		await controller.startFlow();
+		await controller.waitForAuthorization();
+
+		expect(mockWaitForAuthorization).toHaveBeenCalledOnce();
+		expect(mockWaitForAuthorization).toHaveBeenCalledWith(
+			"dc-abc123",
+			5,
+			900,
+			expect.any(Function),
+		);
+	});
+
+	it("waitForAuthorization() 成功時に state が success になること", async () => {
+		mockRequestDeviceCode.mockResolvedValue(deviceCodeResponse);
+		// waitForAuthorization 内で onStateChange コールバックを呼ぶことをシミュレート
+		mockWaitForAuthorization.mockImplementation(
+			async (
+				_deviceCode: string,
+				_interval: number,
+				_expiresIn: number,
+				onStateChange?: (state: DeviceFlowState) => void,
+			) => {
+				onStateChange?.({ phase: "polling" });
+				onStateChange?.({ phase: "success" });
+			},
+		);
+
+		const controller = buildController();
+		await controller.startFlow();
+		await controller.waitForAuthorization();
+
+		expect(controller.getState()).toEqual({ phase: "success" });
+	});
+
+	it("waitForAuthorization() で expired が来た場合、state が expired のまま resolve すること", async () => {
+		mockRequestDeviceCode.mockResolvedValue(deviceCodeResponse);
+		mockWaitForAuthorization.mockImplementation(
+			async (
+				_deviceCode: string,
+				_interval: number,
+				_expiresIn: number,
+				onStateChange?: (state: DeviceFlowState) => void,
+			) => {
+				onStateChange?.({ phase: "polling" });
+				onStateChange?.({ phase: "expired" });
+			},
+		);
+
+		const controller = buildController();
+		await controller.startFlow();
+
+		// expired 時は reject せず resolve する（エラーは内部で処理し state で表現）
+		await expect(controller.waitForAuthorization()).resolves.toBeUndefined();
+		expect(controller.getState()).toEqual({ phase: "expired" });
+	});
+
+	it("waitForAuthorization() で denied が来た場合、state が denied のまま resolve すること", async () => {
+		mockRequestDeviceCode.mockResolvedValue(deviceCodeResponse);
+		mockWaitForAuthorization.mockImplementation(
+			async (
+				_deviceCode: string,
+				_interval: number,
+				_expiresIn: number,
+				onStateChange?: (state: DeviceFlowState) => void,
+			) => {
+				onStateChange?.({ phase: "polling" });
+				onStateChange?.({ phase: "denied" });
+			},
+		);
+
+		const controller = buildController();
+		await controller.startFlow();
+
+		// denied 時も reject せず resolve する（エラーは内部で処理し state で表現）
+		await expect(controller.waitForAuthorization()).resolves.toBeUndefined();
+		expect(controller.getState()).toEqual({ phase: "denied" });
+	});
+
+	it("startFlow() 未実行で waitForAuthorization() を呼ぶとエラーになること", async () => {
+		const controller = buildController();
+
+		await expect(controller.waitForAuthorization()).rejects.toThrow("Device code not available");
+	});
+
+	it("subscribe でリスナーが state 変更を受け取ること", async () => {
+		mockRequestDeviceCode.mockResolvedValue(deviceCodeResponse);
+		mockWaitForAuthorization.mockReturnValue(new Promise(() => {}));
+
+		const controller = buildController();
+		const listener = vi.fn();
+
+		controller.subscribe(listener);
+		await controller.startFlow();
+
+		// awaiting_user への遷移を listener が受け取っている
+		expect(listener).toHaveBeenCalled();
+		const lastCall = listener.mock.calls[listener.mock.calls.length - 1][0] as DeviceFlowState;
+		expect(lastCall.phase).toBe("awaiting_user");
+	});
+
+	it("subscribe の戻り値で unsubscribe できること", async () => {
+		mockRequestDeviceCode.mockResolvedValue(deviceCodeResponse);
+		mockWaitForAuthorization.mockReturnValue(new Promise(() => {}));
+
+		const controller = buildController();
+		const listener = vi.fn();
+
+		const unsubscribe = controller.subscribe(listener);
+		unsubscribe();
+
+		await controller.startFlow();
+
+		// unsubscribe 後は listener が呼ばれない
+		expect(listener).not.toHaveBeenCalled();
+	});
+
+	it("startFlow() を2回呼んだ場合、状態がリセットされ新しい device code に更新されること", async () => {
+		const secondDeviceCodeResponse: DeviceCodeResponse = {
+			deviceCode: "dc-xyz789",
+			userCode: "WXYZ-5678",
+			verificationUri: "https://github.com/login/device",
+			expiresIn: 600,
+			interval: 10,
+		};
+
+		mockRequestDeviceCode
+			.mockResolvedValueOnce(deviceCodeResponse)
+			.mockResolvedValueOnce(secondDeviceCodeResponse);
+		mockWaitForAuthorization.mockReturnValue(new Promise(() => {}));
+
+		const controller = buildController();
+
+		await controller.startFlow();
+		expect(controller.getState()).toEqual({
+			phase: "awaiting_user",
+			userCode: "ABCD-1234",
+			verificationUri: "https://github.com/login/device",
+		});
+
+		await controller.startFlow();
+		expect(controller.getState()).toEqual({
+			phase: "awaiting_user",
+			userCode: "WXYZ-5678",
+			verificationUri: "https://github.com/login/device",
+		});
+
+		expect(mockRequestDeviceCode).toHaveBeenCalledTimes(2);
+	});
+
+	it("startAndWait() が startFlow → waitForAuthorization を順次実行すること", async () => {
+		mockRequestDeviceCode.mockResolvedValue(deviceCodeResponse);
+		mockWaitForAuthorization.mockImplementation(
+			async (
+				_deviceCode: string,
+				_interval: number,
+				_expiresIn: number,
+				onStateChange?: (state: DeviceFlowState) => void,
+			) => {
+				onStateChange?.({ phase: "polling" });
+				onStateChange?.({ phase: "success" });
+			},
+		);
+
+		const controller = buildController();
+		const listener = vi.fn();
+		controller.subscribe(listener);
+
+		await controller.startAndWait();
+
+		// requestDeviceCode と waitForAuthorization が両方呼ばれている
+		expect(mockRequestDeviceCode).toHaveBeenCalledOnce();
+		expect(mockWaitForAuthorization).toHaveBeenCalledOnce();
+		expect(controller.getState()).toEqual({ phase: "success" });
+
+		// state 遷移の順序: awaiting_user → polling → success
+		const phases = listener.mock.calls.map((call) => (call[0] as DeviceFlowState).phase);
+		expect(phases).toEqual(["awaiting_user", "polling", "success"]);
+	});
+
+	it("startAndWait() で startFlow が失敗した場合、waitForAuthorization は呼ばれないこと", async () => {
+		mockRequestDeviceCode.mockRejectedValue(new Error("Network failure"));
+
+		const controller = buildController();
+
+		await controller.startAndWait();
+
+		expect(mockRequestDeviceCode).toHaveBeenCalledOnce();
+		expect(mockWaitForAuthorization).not.toHaveBeenCalled();
+		expect(controller.getState().phase).toBe("error");
+	});
+
+	it("catch 防御: onStateChange 未呼び出しで throw された場合に error state に遷移すること", async () => {
+		mockRequestDeviceCode.mockResolvedValue(deviceCodeResponse);
+		// onStateChange を呼ばずに直接 throw する
+		mockWaitForAuthorization.mockRejectedValue(new Error("Unexpected crash"));
+
+		const controller = buildController();
+		await controller.startFlow();
+
+		// startFlow 後は awaiting_user のはず
+		expect(controller.getState().phase).toBe("awaiting_user");
+
+		await controller.waitForAuthorization();
+
+		// catch 防御により error state に遷移している
+		const state = controller.getState();
+		expect(state.phase).toBe("error");
+		if (state.phase === "error") {
+			expect(state.message).toBe("Unexpected crash");
+		}
+	});
+
+	it("catch 防御: onStateChange で expired に遷移済みの場合、error に上書きしないこと", async () => {
+		mockRequestDeviceCode.mockResolvedValue(deviceCodeResponse);
+		mockWaitForAuthorization.mockImplementation(
+			async (
+				_deviceCode: string,
+				_interval: number,
+				_expiresIn: number,
+				onStateChange?: (state: DeviceFlowState) => void,
+			) => {
+				onStateChange?.({ phase: "expired" });
+				throw new Error("Device flow expired");
+			},
+		);
+
+		const controller = buildController();
+		await controller.startFlow();
+		await controller.waitForAuthorization();
+
+		// expired のまま、error に上書きされていない
+		expect(controller.getState()).toEqual({ phase: "expired" });
+	});
+});


### PR DESCRIPTION
## 概要
Svelte コンポーネント (App.svelte, LoginScreen.svelte) に直接記述されていた Device Flow の状態管理ロジック（ポーリング制御、状態遷移、セッション情報保持）を TypeScript usecase 層の `DeviceFlowController` に分離し、CLAUDE.md の責務分担ルール「Svelte: UI 表示のみ。ロジックを持たない」に準拠させた。

## 変更内容
- `src/shared/usecase/device-flow.controller.ts`: 新規作成。Device Flow 全体のオーケストレーション（startFlow, waitForAuthorization, startAndWait）と状態管理（subscribe パターン）を提供する DeviceFlowController ファクトリ関数
- `src/sidepanel/App.svelte`: pendingDeviceCode 等の中間状態と handleStartDeviceFlow/handleWaitForAuthorization を削除。DeviceFlowController を Props で受け取り、subscribe で success 時に authenticated = true を設定するのみに簡素化
- `src/sidepanel/components/LoginScreen.svelte`: フロー制御ロジックを削除し controller.startAndWait() を呼ぶだけに。再入防止 (inProgress)、polling 中の userCode 保持 (lastUserCode)、error 変数の二重管理解消を実施
- `src/sidepanel/main.ts`: createDeviceFlowController(authUseCase) でコントローラを生成し App に注入
- `src/test/shared/usecase/device-flow.controller.test.ts`: 新規作成。16テストケースで startFlow/waitForAuthorization/startAndWait/subscribe/エッジケースをカバー

## 関連 Issue
- closes #101

## テスト
- [x] TypeScript 型チェック通過 (`pnpm check`)
- [x] フロントエンドテスト通過 (`pnpm test`) — 322 tests passed
- [x] Rust lint 通過 (`cargo clippy --all-targets`)
- [x] Rust テスト通過 (`cargo test`) — 110 tests passed
- [x] `/verify` で検証ループ PASS

## レビュー観点
- DeviceFlowController の設計: startFlow/waitForAuthorization を分離した上で startAndWait で一括実行できるインターフェースが適切か
- catch 節の防御コード (67-72行目): onStateChange 未呼び出しでの throw に対するフォールバックが過剰/不足でないか
- LoginScreen の残存ロジック: inProgress/lastUserCode/handleCopyCode/openVerificationUri が Svelte 側に残っているのは UI 表示責務の範囲内か