### PR TITLE
feat: PR状態バッジ表示を実装 (#14)

### DIFF
--- a/src/sidepanel/components/ApprovalBadge.svelte
+++ b/src/sidepanel/components/ApprovalBadge.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+	import "../styles/badge.css";
+
+	type Props = {
+		approvalStatus: string;
+	};
+
+	const { approvalStatus }: Props = $props();
+
+	// 表示ポリシー: "Pending" (レビュー依頼なし) は非表示。まだ誰にもレビュー依頼していない状態のため、
+	// バッジで表示するまでもない。CiBadge の "Pending" は CI がキュー待ちの意味で表示する。
+	// "Pending" と不正値は意図的に非表示。
+	// config に存在しないキーは $derived で undefined → {#if resolved} で非表示になる。
+	const config: Record<string, { label: string; colorClass: string }> = {
+		Approved: { label: "APPROVED", colorClass: "badge-green" },
+		ChangesRequested: { label: "CHANGES REQUESTED", colorClass: "badge-red" },
+		ReviewRequired: { label: "REVIEW REQUIRED", colorClass: "badge-yellow" },
+	};
+
+	const resolved = $derived(config[approvalStatus]);
+</script>
+
+{#if resolved}
+	<span class="badge {resolved.colorClass}">{resolved.label}</span>
+{/if}

--- a/src/sidepanel/components/CiBadge.svelte
+++ b/src/sidepanel/components/CiBadge.svelte
@@ -1,0 +1,42 @@
+<script lang="ts">
+	import "../styles/badge.css";
+
+	type Props = {
+		ciStatus: string;
+	};
+
+	const { ciStatus }: Props = $props();
+
+	// "None" (CI 未設定) と不正値は意図的に非表示。
+	// config に存在しないキーは $derived で undefined → {#if resolved} で非表示になる。
+	const config: Record<string, { label: string; colorClass: string; animate: boolean }> = {
+		Passed: { label: "CI PASSED", colorClass: "badge-green", animate: false },
+		Failed: { label: "CI FAILED", colorClass: "badge-red", animate: false },
+		Running: { label: "CI RUNNING", colorClass: "badge-yellow", animate: true },
+		Pending: { label: "CI PENDING", colorClass: "badge-gray", animate: false },
+	};
+
+	const resolved = $derived(config[ciStatus]);
+</script>
+
+{#if resolved}
+	<span class="badge {resolved.colorClass}" class:badge-animate={resolved.animate}
+		>{resolved.label}</span
+	>
+{/if}
+
+<style>
+	.badge-animate {
+		animation: pulse 1.5s ease-in-out infinite;
+	}
+
+	@keyframes pulse {
+		0%,
+		100% {
+			opacity: 1;
+		}
+		50% {
+			opacity: 0.5;
+		}
+	}
+</style>

--- a/src/sidepanel/components/DraftBadge.svelte
+++ b/src/sidepanel/components/DraftBadge.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+	import "../styles/badge.css";
+
+	type Props = {
+		isDraft: boolean;
+	};
+
+	const { isDraft }: Props = $props();
+</script>
+
+{#if isDraft}
+	<span class="badge badge-gray">DRAFT</span>
+{/if}

--- a/src/sidepanel/components/PrItem.svelte
+++ b/src/sidepanel/components/PrItem.svelte
@@ -2,6 +2,9 @@
 	import type { PrItemDto } from "../../domain/ports/pr-processor.port";
 	import { formatRelativeTime } from "../../shared/utils/time";
 	import { safeUrl } from "../../shared/utils/url";
+	import ApprovalBadge from "./ApprovalBadge.svelte";
+	import CiBadge from "./CiBadge.svelte";
+	import DraftBadge from "./DraftBadge.svelte";
 
 	type Props = {
 		pr: PrItemDto;
@@ -17,6 +20,13 @@
 	<div class="pr-meta">
 		<span class="pr-repo">{pr.repository}</span>
 		<span class="pr-updated">{formatRelativeTime(pr.updatedAt)}</span>
+	</div>
+	<div class="pr-badges">
+		<DraftBadge isDraft={pr.isDraft} />
+		{#if !pr.isDraft}
+			<ApprovalBadge approvalStatus={pr.approvalStatus} />
+			<CiBadge ciStatus={pr.ciStatus} />
+		{/if}
 	</div>
 </div>
 
@@ -44,5 +54,12 @@
 		font-size: 0.75rem;
 		color: #586069;
 		margin-top: 0.25rem;
+	}
+
+	.pr-badges {
+		display: flex;
+		gap: 0.25rem;
+		margin-top: 0.25rem;
+		flex-wrap: wrap;
 	}
 </style>

--- a/src/sidepanel/styles/badge.css
+++ b/src/sidepanel/styles/badge.css
@@ -1,0 +1,25 @@
+.badge {
+	display: inline-block;
+	padding: 0.125rem 0.375rem;
+	border-radius: 9999px;
+	font-size: 0.625rem;
+	font-weight: 600;
+	color: #fff;
+	line-height: 1.4;
+}
+
+.badge-green {
+	background-color: #28a745;
+}
+
+.badge-red {
+	background-color: #d73a49;
+}
+
+.badge-yellow {
+	background-color: #dbab09;
+}
+
+.badge-gray {
+	background-color: #586069;
+}

--- a/src/test/sidepanel/components/ApprovalBadge.test.ts
+++ b/src/test/sidepanel/components/ApprovalBadge.test.ts
@@ -1,0 +1,74 @@
+import { mount, unmount } from "svelte";
+import { afterEach, describe, expect, it } from "vitest";
+import ApprovalBadge from "../../../sidepanel/components/ApprovalBadge.svelte";
+
+describe("ApprovalBadge", () => {
+	let component: ReturnType<typeof mount>;
+
+	afterEach(() => {
+		if (component) {
+			unmount(component);
+		}
+		document.body.innerHTML = "";
+	});
+
+	it("should render APPROVED badge with green class when status is Approved", () => {
+		component = mount(ApprovalBadge, {
+			target: document.body,
+			props: { approvalStatus: "Approved" },
+		});
+		const badge = document.querySelector(".badge");
+		expect(badge).not.toBeNull();
+		expect(badge?.textContent?.trim()).toBe("APPROVED");
+		expect(badge?.classList.contains("badge-green")).toBe(true);
+	});
+
+	it("should render CHANGES REQUESTED badge with red class when status is ChangesRequested", () => {
+		component = mount(ApprovalBadge, {
+			target: document.body,
+			props: { approvalStatus: "ChangesRequested" },
+		});
+		const badge = document.querySelector(".badge");
+		expect(badge).not.toBeNull();
+		expect(badge?.textContent?.trim()).toBe("CHANGES REQUESTED");
+		expect(badge?.classList.contains("badge-red")).toBe(true);
+	});
+
+	it("should render REVIEW REQUIRED badge with yellow class when status is ReviewRequired", () => {
+		component = mount(ApprovalBadge, {
+			target: document.body,
+			props: { approvalStatus: "ReviewRequired" },
+		});
+		const badge = document.querySelector(".badge");
+		expect(badge).not.toBeNull();
+		expect(badge?.textContent?.trim()).toBe("REVIEW REQUIRED");
+		expect(badge?.classList.contains("badge-yellow")).toBe(true);
+	});
+
+	it("should render nothing when status is Pending", () => {
+		component = mount(ApprovalBadge, {
+			target: document.body,
+			props: { approvalStatus: "Pending" },
+		});
+		const badge = document.querySelector(".badge");
+		expect(badge).toBeNull();
+	});
+
+	it("should render nothing when status is an empty string", () => {
+		component = mount(ApprovalBadge, {
+			target: document.body,
+			props: { approvalStatus: "" },
+		});
+		const badge = document.querySelector(".badge");
+		expect(badge).toBeNull();
+	});
+
+	it("should render nothing when status is an unknown value", () => {
+		component = mount(ApprovalBadge, {
+			target: document.body,
+			props: { approvalStatus: "InvalidValue" },
+		});
+		const badge = document.querySelector(".badge");
+		expect(badge).toBeNull();
+	});
+});

--- a/src/test/sidepanel/components/CiBadge.test.ts
+++ b/src/test/sidepanel/components/CiBadge.test.ts
@@ -1,0 +1,87 @@
+import { mount, unmount } from "svelte";
+import { afterEach, describe, expect, it } from "vitest";
+import CiBadge from "../../../sidepanel/components/CiBadge.svelte";
+
+describe("CiBadge", () => {
+	let component: ReturnType<typeof mount>;
+
+	afterEach(() => {
+		if (component) {
+			unmount(component);
+		}
+		document.body.innerHTML = "";
+	});
+
+	it("should render CI PASSED badge with green class when status is Passed", () => {
+		component = mount(CiBadge, {
+			target: document.body,
+			props: { ciStatus: "Passed" },
+		});
+		const badge = document.querySelector(".badge");
+		expect(badge).not.toBeNull();
+		expect(badge?.textContent?.trim()).toBe("CI PASSED");
+		expect(badge?.classList.contains("badge-green")).toBe(true);
+		expect(badge?.classList.contains("badge-animate")).toBe(false);
+	});
+
+	it("should render CI FAILED badge with red class when status is Failed", () => {
+		component = mount(CiBadge, {
+			target: document.body,
+			props: { ciStatus: "Failed" },
+		});
+		const badge = document.querySelector(".badge");
+		expect(badge).not.toBeNull();
+		expect(badge?.textContent?.trim()).toBe("CI FAILED");
+		expect(badge?.classList.contains("badge-red")).toBe(true);
+	});
+
+	it("should render CI RUNNING badge with yellow class and animation when status is Running", () => {
+		component = mount(CiBadge, {
+			target: document.body,
+			props: { ciStatus: "Running" },
+		});
+		const badge = document.querySelector(".badge");
+		expect(badge).not.toBeNull();
+		expect(badge?.textContent?.trim()).toBe("CI RUNNING");
+		expect(badge?.classList.contains("badge-yellow")).toBe(true);
+		expect(badge?.classList.contains("badge-animate")).toBe(true);
+	});
+
+	it("should render CI PENDING badge with gray class when status is Pending", () => {
+		component = mount(CiBadge, {
+			target: document.body,
+			props: { ciStatus: "Pending" },
+		});
+		const badge = document.querySelector(".badge");
+		expect(badge).not.toBeNull();
+		expect(badge?.textContent?.trim()).toBe("CI PENDING");
+		expect(badge?.classList.contains("badge-gray")).toBe(true);
+	});
+
+	it("should render nothing when status is None", () => {
+		component = mount(CiBadge, {
+			target: document.body,
+			props: { ciStatus: "None" },
+		});
+		const badge = document.querySelector(".badge");
+		expect(badge).toBeNull();
+	});
+
+	it("should render nothing when status is an empty string", () => {
+		component = mount(CiBadge, {
+			target: document.body,
+			props: { ciStatus: "" },
+		});
+		const badge = document.querySelector(".badge");
+		expect(badge).toBeNull();
+	});
+
+	it("should render nothing when status is an unknown value", () => {
+		component = mount(CiBadge, {
+			target: document.body,
+			props: { ciStatus: "UnknownStatus" },
+		});
+		const badge = document.querySelector(".badge");
+		expect(badge).toBeNull();
+	});
+});

--- a/src/test/sidepanel/components/DraftBadge.test.ts
+++ b/src/test/sidepanel/components/DraftBadge.test.ts
@@ -1,0 +1,34 @@
+import { mount, unmount } from "svelte";
+import { afterEach, describe, expect, it } from "vitest";
+import DraftBadge from "../../../sidepanel/components/DraftBadge.svelte";
+
+describe("DraftBadge", () => {
+	let component: ReturnType<typeof mount>;
+
+	afterEach(() => {
+		if (component) {
+			unmount(component);
+		}
+		document.body.innerHTML = "";
+	});
+
+	it("should render DRAFT badge with gray class when isDraft is true", () => {
+		component = mount(DraftBadge, {
+			target: document.body,
+			props: { isDraft: true },
+		});
+		const badge = document.querySelector(".badge");
+		expect(badge).not.toBeNull();
+		expect(badge?.textContent?.trim()).toBe("DRAFT");
+		expect(badge?.classList.contains("badge-gray")).toBe(true);
+	});
+
+	it("should render nothing when isDraft is false", () => {
+		component = mount(DraftBadge, {
+			target: document.body,
+			props: { isDraft: false },
+		});
+		const badge = document.querySelector(".badge");
+		expect(badge).toBeNull();
+	});
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,6 +3,9 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
 	plugins: [svelte({ hot: false })],
+	resolve: {
+		conditions: ["browser"],
+	},
 	test: {
 		include: ["src/**/*.test.ts"],
 		environment: "jsdom",


### PR DESCRIPTION
## 概要
各 PR 行に ApprovalBadge / CiBadge / DraftBadge の状態バッジを表示する。Draft PR の場合は DRAFT バッジのみ表示し、Approval/CI バッジは非表示にする。

## 変更内容
- `src/sidepanel/components/ApprovalBadge.svelte`: 新規。APPROVED(緑)/CHANGES REQUESTED(赤)/REVIEW REQUIRED(黄) を表示。Pending・不正値は非表示
- `src/sidepanel/components/CiBadge.svelte`: 新規。CI PASSED(緑)/FAILED(赤)/RUNNING(黄+pulse)/PENDING(灰) を表示。None・不正値は非表示
- `src/sidepanel/components/DraftBadge.svelte`: 新規。isDraft=true で DRAFT(灰) バッジ表示
- `src/sidepanel/styles/badge.css`: 新規。共通バッジベーススタイル + 色クラスを一元管理
- `src/sidepanel/components/PrItem.svelte`: 3バッジを pr-badges div に組み込み。Draft 時は他バッジ非表示
- `vitest.config.ts`: resolve.conditions に "browser" 追加 (Svelte 5 mount テスト対応)
- `src/test/sidepanel/components/ApprovalBadge.test.ts`: 6テスト (4状態 + 空文字 + 不正値)
- `src/test/sidepanel/components/CiBadge.test.ts`: 7テスト (5状態 + 空文字 + 不正値 + animate非付与)
- `src/test/sidepanel/components/DraftBadge.test.ts`: 2テスト (true/false)

## 関連 Issue
- closes #14

## テスト
- [x] TypeScript 型チェック通過 (`pnpm check`)
- [x] フロントエンドテスト通過 (`pnpm test`) — 323 tests all passed
- [x] Rust lint 通過 (`cargo clippy --all-targets`)
- [x] Rust テスト通過 (`cargo test`)
- [x] `/verify` で検証ループ PASS

## レビュー観点
- バッジの表示/非表示ポリシー: Pending (Approval) と None (CI) は意図的に非表示。設計判断はコメントで明記済み
- Draft PR 時の排他制御: `{#if !pr.isDraft}` で ApprovalBadge/CiBadge を非表示にしている
- CSS 共通化: badge.css にベース + 色クラスを一元管理。CiBadge のみ .badge-animate を scoped で保持
- TS 型安全性: approvalStatus/ciStatus が string 型の課題は #131 で別途対応予定