### PR TITLE
fix: GitHubApiError.details の本番ビルド漏洩リスク対策

### DIFF
--- a/src/adapter/github/dev-details.ts
+++ b/src/adapter/github/dev-details.ts
@@ -1,0 +1,14 @@
+/**
+ * 本番ビルドで内部エラー情報が details に漏洩しないように、
+ * DEV モードでのみ details を返すヘルパー。
+ * Vite が import.meta.env.DEV をビルド時に静的置換するため、
+ * 本番バンドルではデッドコード除去される。
+ */
+export function devOnlyDetails(error: unknown): string | undefined {
+	if (!import.meta.env.DEV) return undefined;
+	return error instanceof Error ? error.message : undefined;
+}
+
+export function devOnlyMessage(message: string): string | undefined {
+	return import.meta.env.DEV ? message : undefined;
+}

--- a/src/adapter/github/graphql-client.ts
+++ b/src/adapter/github/graphql-client.ts
@@ -1,6 +1,7 @@
 import type { GitHubApiPort } from "../../domain/ports/github-api.port";
 import type { FetchRawPullRequestsResult } from "../../domain/types/github";
 import { GitHubApiError } from "../../shared/types/errors";
+import { devOnlyDetails, devOnlyMessage } from "./dev-details";
 import { extractRateLimitInfo } from "./rate-limit";
 import type { DelayFn, RetryConfig } from "./retry";
 import { defaultDelay, withRetry } from "./retry";
@@ -144,8 +145,12 @@ export class GitHubGraphQLClient implements GitHubApiPort {
 		try {
 			body = JSON.parse(rawJson) as GraphQLResponse;
 		} catch (error: unknown) {
-			const details = error instanceof Error ? error.message : undefined;
-			throw new GitHubApiError("unknown", "Failed to parse API response", undefined, details);
+			throw new GitHubApiError(
+				"unknown",
+				"Failed to parse API response",
+				undefined,
+				devOnlyDetails(error),
+			);
 		}
 
 		this.checkGraphQLErrors(body);
@@ -173,8 +178,12 @@ export class GitHubGraphQLClient implements GitHubApiPort {
 				body: JSON.stringify({ query: PULL_REQUESTS_QUERY }),
 			});
 		} catch (error: unknown) {
-			const details = error instanceof Error ? error.message : undefined;
-			throw new GitHubApiError("network_error", "Network request failed", undefined, details);
+			throw new GitHubApiError(
+				"network_error",
+				"Network request failed",
+				undefined,
+				devOnlyDetails(error),
+			);
 		}
 
 		if (!response.ok) {
@@ -219,8 +228,12 @@ export class GitHubGraphQLClient implements GitHubApiPort {
 		try {
 			return await response.text();
 		} catch (error: unknown) {
-			const details = error instanceof Error ? error.message : undefined;
-			throw new GitHubApiError("unknown", "Failed to parse API response", undefined, details);
+			throw new GitHubApiError(
+				"unknown",
+				"Failed to parse API response",
+				undefined,
+				devOnlyDetails(error),
+			);
 		}
 	}
 
@@ -228,7 +241,7 @@ export class GitHubGraphQLClient implements GitHubApiPort {
 	// 部分的に有効なデータがあっても、整合性が保証できないため一律エラー扱い。
 	private checkGraphQLErrors(body: GraphQLResponse): void {
 		if (body.errors && body.errors.length > 0) {
-			const details = body.errors.map((e) => e.message).join("; ");
+			const details = devOnlyMessage(body.errors.map((e) => e.message).join("; "));
 			throw new GitHubApiError(
 				"graphql_error",
 				"GitHub API returned GraphQL errors",

--- a/src/test/adapter/github/graphql-client.test.ts
+++ b/src/test/adapter/github/graphql-client.test.ts
@@ -4,6 +4,14 @@ import type { DelayFn } from "../../../adapter/github/retry";
 import type { GitHubApiPort } from "../../../domain/ports/github-api.port";
 import { GitHubApiError } from "../../../shared/types/errors";
 
+vi.mock("../../../adapter/github/dev-details", async (importOriginal) => {
+	const original = await importOriginal<typeof import("../../../adapter/github/dev-details")>();
+	return {
+		devOnlyDetails: vi.fn(original.devOnlyDetails),
+		devOnlyMessage: vi.fn(original.devOnlyMessage),
+	};
+});
+
 const noDelay: DelayFn = () => Promise.resolve();
 
 const GRAPHQL_ENDPOINT = "https://api.github.com/graphql";
@@ -753,6 +761,89 @@ describe("GitHubGraphQLClient", () => {
 
 			expect(result.rawJson).toBe(rawJson);
 			expect(fetchMock).toHaveBeenCalledTimes(2);
+		});
+	});
+
+	describe("fetchPullRequests - 本番ビルドでの details 除外", () => {
+		let devDetails: typeof import("../../../adapter/github/dev-details");
+
+		beforeEach(async () => {
+			devDetails = await import("../../../adapter/github/dev-details");
+			vi.mocked(devDetails.devOnlyDetails).mockReturnValue(undefined);
+			vi.mocked(devDetails.devOnlyMessage).mockReturnValue(undefined);
+		});
+
+		afterEach(() => {
+			vi.restoreAllMocks();
+		});
+
+		it("network_error (fetch rejection) 時に PROD では details が undefined", async () => {
+			const noRetryClient = new GitHubGraphQLClient(mockGetAccessToken, { maxRetries: 0 });
+			globalThis.fetch = vi.fn().mockRejectedValue(new TypeError("Failed to fetch"));
+
+			const error = await noRetryClient.fetchPullRequests().catch((e: unknown) => e);
+
+			expect(error).toBeInstanceOf(GitHubApiError);
+			expect((error as GitHubApiError).code).toBe("network_error");
+			expect((error as GitHubApiError).details).toBeUndefined();
+		});
+
+		it("graphql_error 時に PROD では details が undefined", async () => {
+			const noRetryClient = new GitHubGraphQLClient(mockGetAccessToken, { maxRetries: 0 });
+			const errorJson = JSON.stringify({
+				errors: [{ message: "Field 'foo' doesn't exist" }],
+			});
+			globalThis.fetch = vi.fn().mockResolvedValue({
+				ok: true,
+				text: async () => errorJson,
+			});
+
+			const error = await noRetryClient.fetchPullRequests().catch((e: unknown) => e);
+
+			expect(error).toBeInstanceOf(GitHubApiError);
+			expect((error as GitHubApiError).code).toBe("graphql_error");
+			expect((error as GitHubApiError).details).toBeUndefined();
+		});
+
+		it("JSON パースエラー (unknown) 時に PROD では details が undefined", async () => {
+			const noRetryClient = new GitHubGraphQLClient(mockGetAccessToken, { maxRetries: 0 });
+			globalThis.fetch = vi.fn().mockResolvedValue({
+				ok: true,
+				text: async () => "<html>Not JSON</html>",
+			});
+
+			const error = await noRetryClient.fetchPullRequests().catch((e: unknown) => e);
+
+			expect(error).toBeInstanceOf(GitHubApiError);
+			expect((error as GitHubApiError).code).toBe("unknown");
+			expect((error as GitHubApiError).details).toBeUndefined();
+		});
+
+		it("response.text() 失敗 (unknown) 時に PROD では details が undefined", async () => {
+			const noRetryClient = new GitHubGraphQLClient(mockGetAccessToken, { maxRetries: 0 });
+			globalThis.fetch = vi.fn().mockResolvedValue({
+				ok: true,
+				text: async () => {
+					throw new Error("body stream already read");
+				},
+			});
+
+			const error = await noRetryClient.fetchPullRequests().catch((e: unknown) => e);
+
+			expect(error).toBeInstanceOf(GitHubApiError);
+			expect((error as GitHubApiError).code).toBe("unknown");
+			expect((error as GitHubApiError).details).toBeUndefined();
+		});
+
+		it("DEV モードでは network_error 時に details が設定される", async () => {
+			vi.restoreAllMocks();
+			const noRetryClient = new GitHubGraphQLClient(mockGetAccessToken, { maxRetries: 0 });
+			globalThis.fetch = vi.fn().mockRejectedValue(new TypeError("Failed to fetch"));
+
+			const error = await noRetryClient.fetchPullRequests().catch((e: unknown) => e);
+
+			expect(error).toBeInstanceOf(GitHubApiError);
+			expect((error as GitHubApiError).details).toBe("Failed to fetch");
 		});
 	});
 });


### PR DESCRIPTION
## 概要
本番ビルドで GitHubApiError.details に内部エラー情報が含まれないようにするセキュリティ改善。

## 変更内容
- src/adapter/github/dev-details.ts: DEV モードでのみ details を返すヘルパー関数を新規作成
- src/adapter/github/graphql-client.ts: 4箇所の details 設定を devOnlyDetails/devOnlyMessage 経由に変更
- src/test/adapter/github/graphql-client.test.ts: PROD 相当環境での details 除外テスト5件追加

## 関連 Issue
- closes #93

## テスト
- [x] TypeScript 型チェック通過
- [x] フロントエンドテスト通過 (313/313 PASS)
- [x] /verify で検証ループ PASS

## レビュー観点
- devOnlyDetails/devOnlyMessage が import.meta.env.DEV で正しく条件分岐しているか
- Vite の静的置換による本番デッドコード除去の妥当性