### PR TITLE
feat: ダークテーマ対応 & CSS Variables によるデザイントークン管理

### DIFF
--- a/src/sidepanel/App.svelte
+++ b/src/sidepanel/App.svelte
@@ -47,9 +47,22 @@
 </script>
 
 {#if loading}
-	<p>Loading...</p>
+	<div class="loading">
+		<p>Loading...</p>
+	</div>
 {:else if authenticated}
 	<MainScreen onLogout={handleLogout} fetchPrs={() => prUseCase.fetchPrs("@me")} />
 {:else}
 	<LoginScreen controller={deviceFlowController} />
 {/if}
+
+<style>
+	.loading {
+		display: flex;
+		justify-content: center;
+		align-items: center;
+		min-height: 100vh;
+		color: var(--color-text-secondary);
+		font-size: 0.875rem;
+	}
+</style>

--- a/src/sidepanel/components/CiBadge.svelte
+++ b/src/sidepanel/components/CiBadge.svelte
@@ -39,4 +39,10 @@
 			opacity: 0.5;
 		}
 	}
+
+	@media (prefers-reduced-motion: reduce) {
+		.badge-animate {
+			animation: none;
+		}
+	}
 </style>

--- a/src/sidepanel/components/LoginScreen.svelte
+++ b/src/sidepanel/components/LoginScreen.svelte
@@ -93,22 +93,45 @@
 		display: flex;
 		flex-direction: column;
 		align-items: center;
-		padding: 2rem;
+		padding: 2rem 1rem;
 		gap: 1rem;
+		min-height: 100vh;
+		background: var(--color-bg-primary);
+	}
+
+	h2 {
+		color: var(--color-text-primary);
+		font-size: 1rem;
+	}
+
+	p {
+		color: var(--color-text-secondary);
+		font-size: 0.875rem;
+		text-align: center;
 	}
 
 	.login-btn {
-		padding: 0.75rem 1.5rem;
-		font-size: 1rem;
+		padding: 0.625rem 1.25rem;
+		font-size: 0.875rem;
 		cursor: pointer;
-		border: 1px solid #ccc;
+		border: 1px solid var(--color-border-primary);
 		border-radius: 6px;
-		background: #24292e;
-		color: #fff;
+		background: var(--color-accent-primary);
+		color: var(--color-bg-primary);
+		font-weight: 600;
+		transition: opacity 0.15s;
+	}
+
+	.login-btn:hover {
+		opacity: 0.85;
+	}
+
+	.login-btn:active {
+		opacity: 0.7;
 	}
 
 	.login-btn:disabled {
-		opacity: 0.6;
+		opacity: 0.4;
 		cursor: not-allowed;
 	}
 
@@ -118,13 +141,16 @@
 		align-items: center;
 		gap: 0.75rem;
 		padding: 1rem;
-		border: 1px solid #e1e4e8;
+		border: 1px solid var(--color-border-primary);
 		border-radius: 8px;
-		background: #f6f8fa;
+		background: var(--color-bg-secondary);
+		width: 100%;
+		max-width: 320px;
 	}
 
 	.instruction {
 		font-weight: 600;
+		color: var(--color-text-primary);
 	}
 
 	.user-code-container {
@@ -134,41 +160,56 @@
 	}
 
 	.user-code {
-		font-size: 1.5rem;
+		font-size: 1.25rem;
 		font-weight: bold;
 		letter-spacing: 0.15em;
-		padding: 0.5rem 1rem;
-		background: #fff;
-		border: 2px solid #0366d6;
+		padding: 0.375rem 0.75rem;
+		background: var(--color-bg-primary);
+		border: 2px solid var(--color-accent-primary);
 		border-radius: 6px;
+		color: var(--color-accent-primary);
 	}
 
 	.copy-btn {
-		padding: 0.4rem 0.8rem;
+		padding: 0.375rem 0.625rem;
 		cursor: pointer;
-		border: 1px solid #ccc;
+		border: 1px solid var(--color-border-primary);
 		border-radius: 4px;
-		background: #fff;
-		font-size: 0.85rem;
+		background: var(--color-bg-hover);
+		color: var(--color-text-primary);
+		font-size: 0.8125rem;
+		transition: background 0.15s;
+	}
+
+	.copy-btn:hover {
+		background: var(--color-bg-secondary);
+	}
+
+	.copy-btn:active {
+		background: var(--color-border-primary);
 	}
 
 	.verification-link {
-		color: #0366d6;
+		color: var(--color-accent-primary);
 		text-decoration: underline;
 		cursor: pointer;
+		font-size: 0.8125rem;
 	}
 
 	.polling-status {
-		color: #586069;
+		color: var(--color-text-secondary);
 		font-style: italic;
+		font-size: 0.8125rem;
 	}
 
 	.error {
-		color: #d73a49;
+		color: var(--color-badge-red);
+		font-size: 0.8125rem;
 	}
 
 	.success {
-		color: #28a745;
+		color: var(--color-badge-green);
 		font-weight: 600;
+		font-size: 0.875rem;
 	}
 </style>

--- a/src/sidepanel/components/LogoutButton.svelte
+++ b/src/sidepanel/components/LogoutButton.svelte
@@ -25,21 +25,23 @@
 
 <style>
 	button {
-		padding: 0.5rem 1rem;
-		font-size: 0.875rem;
+		padding: 0.25rem 0.625rem;
+		font-size: 0.75rem;
 		cursor: pointer;
-		border: 1px solid #ccc;
+		border: 1px solid var(--color-border-primary);
 		border-radius: 4px;
 		background: transparent;
-		color: #586069;
+		color: var(--color-text-secondary);
+		transition: background 0.15s, color 0.15s;
 	}
 
 	button:hover {
-		background: #f6f8fa;
+		background: var(--color-bg-hover);
+		color: var(--color-text-primary);
 	}
 
 	.error {
-		color: #d73a49;
-		font-size: 0.875rem;
+		color: var(--color-badge-red);
+		font-size: 0.75rem;
 	}
 </style>

--- a/src/sidepanel/components/MainScreen.svelte
+++ b/src/sidepanel/components/MainScreen.svelte
@@ -79,10 +79,24 @@
 		display: flex;
 		justify-content: space-between;
 		align-items: center;
+		padding: 0.5rem 0;
+		border-bottom: 1px solid var(--color-border-primary);
+		position: sticky;
+		top: 0;
+		background: var(--color-bg-primary);
+		z-index: 10;
+	}
+
+	h1 {
+		font-size: 0.875rem;
+		font-weight: 600;
+		color: var(--color-text-primary);
 	}
 
 	main {
-		padding: 1rem;
+		padding: 0.75rem;
+		min-height: 100vh;
+		background: var(--color-bg-primary);
 	}
 
 	.error-container {
@@ -91,21 +105,26 @@
 	}
 
 	.error {
-		color: #d73a49;
+		color: var(--color-badge-red);
 	}
 
 	.retry-button {
 		margin-top: 0.5rem;
 		padding: 0.375rem 0.75rem;
-		background: #0366d6;
-		color: white;
+		background: var(--color-accent-primary);
+		color: var(--color-bg-primary);
 		border: none;
 		border-radius: 4px;
 		cursor: pointer;
 		font-size: 0.875rem;
+		transition: opacity 0.15s;
 	}
 
 	.retry-button:hover {
-		background: #0256b9;
+		opacity: 0.85;
+	}
+
+	.retry-button:active {
+		opacity: 0.7;
 	}
 </style>

--- a/src/sidepanel/components/PrItem.svelte
+++ b/src/sidepanel/components/PrItem.svelte
@@ -32,14 +32,19 @@
 
 <style>
 	.pr-item {
-		padding: 0.5rem 0;
-		border-bottom: 1px solid #e1e4e8;
+		padding: 0.375rem 0.5rem;
+		border-bottom: 1px solid var(--color-border-primary);
+		transition: background 0.15s;
+	}
+
+	.pr-item:hover {
+		background: var(--color-bg-hover);
 	}
 
 	.pr-title {
-		color: #0366d6;
+		color: var(--color-accent-primary);
 		text-decoration: none;
-		font-size: 0.875rem;
+		font-size: 0.8125rem;
 		line-height: 1.4;
 		display: block;
 	}
@@ -51,15 +56,15 @@
 	.pr-meta {
 		display: flex;
 		gap: 0.5rem;
-		font-size: 0.75rem;
-		color: #586069;
-		margin-top: 0.25rem;
+		font-size: 0.6875rem;
+		color: var(--color-text-secondary);
+		margin-top: 0.125rem;
 	}
 
 	.pr-badges {
 		display: flex;
 		gap: 0.25rem;
-		margin-top: 0.25rem;
+		margin-top: 0.125rem;
 		flex-wrap: wrap;
 	}
 </style>

--- a/src/sidepanel/components/PrSection.svelte
+++ b/src/sidepanel/components/PrSection.svelte
@@ -39,7 +39,7 @@
 
 <style>
 	.pr-section {
-		margin-bottom: 1rem;
+		margin-bottom: 0.75rem;
 	}
 
 	.section-header {
@@ -47,44 +47,52 @@
 		align-items: center;
 		gap: 0.5rem;
 		width: 100%;
-		padding: 0.5rem 0;
+		padding: 0.375rem 0.5rem;
 		background: none;
 		border: none;
 		cursor: pointer;
 		text-align: left;
+		border-radius: 4px;
+		transition: background 0.15s;
+		color: var(--color-text-primary);
 	}
 
 	.section-header:hover {
-		background: #f6f8fa;
+		background: var(--color-bg-hover);
+	}
+
+	.section-header:active {
+		background: var(--color-bg-secondary);
 	}
 
 	.toggle-icon {
-		font-size: 0.75rem;
-		color: #586069;
+		font-size: 0.625rem;
+		color: var(--color-text-secondary);
 	}
 
 	.section-title {
-		font-size: 0.875rem;
+		font-size: 0.8125rem;
 		font-weight: 600;
 		margin: 0;
 		flex: 1;
+		color: var(--color-text-primary);
 	}
 
 	.section-count {
-		font-size: 0.75rem;
-		color: #586069;
-		background: #e1e4e8;
-		padding: 0.125rem 0.5rem;
+		font-size: 0.6875rem;
+		color: var(--color-text-secondary);
+		background: var(--color-bg-secondary);
+		padding: 0.0625rem 0.375rem;
 		border-radius: 10px;
 	}
 
 	.section-body {
-		padding-left: 1.25rem;
+		padding-left: 1rem;
 	}
 
 	.empty-message {
-		color: #586069;
-		font-size: 0.875rem;
+		color: var(--color-text-secondary);
+		font-size: 0.8125rem;
 		font-style: italic;
 	}
 </style>

--- a/src/sidepanel/main.ts
+++ b/src/sidepanel/main.ts
@@ -1,3 +1,4 @@
+import "./styles/global.css";
 import { mount } from "svelte";
 import { chromeSendMessage } from "../adapter/chrome/message.adapter";
 import { createAuthUseCase } from "../shared/usecase/auth.usecase";

--- a/src/sidepanel/styles/badge.css
+++ b/src/sidepanel/styles/badge.css
@@ -4,22 +4,22 @@
 	border-radius: 9999px;
 	font-size: 0.625rem;
 	font-weight: 600;
-	color: #fff;
+	color: var(--color-badge-text, #fff);
 	line-height: 1.4;
 }
 
 .badge-green {
-	background-color: #28a745;
+	background-color: var(--color-badge-green, #3fb950);
 }
 
 .badge-red {
-	background-color: #d73a49;
+	background-color: var(--color-badge-red, #f85149);
 }
 
 .badge-yellow {
-	background-color: #dbab09;
+	background-color: var(--color-badge-yellow, #d29922);
 }
 
 .badge-gray {
-	background-color: #586069;
+	background-color: var(--color-badge-gray, #8b949e);
 }

--- a/src/sidepanel/styles/global.css
+++ b/src/sidepanel/styles/global.css
@@ -1,0 +1,49 @@
+:root {
+	/* Background */
+	--color-bg-primary: #0d1117;
+	--color-bg-secondary: #161b22;
+	--color-bg-hover: #1c2128;
+
+	/* Text */
+	--color-text-primary: #c9d1d9;
+	--color-text-secondary: #8b949e;
+
+	/* Border */
+	--color-border-primary: #30363d;
+
+	/* Accent */
+	--color-accent-primary: #58a6ff;
+
+	/* Badge */
+	--color-badge-text: #ffffff;
+	--color-badge-green: #3fb950;
+	--color-badge-red: #f85149;
+	--color-badge-yellow: #d29922;
+	--color-badge-gray: #8b949e;
+}
+
+*,
+*::before,
+*::after {
+	box-sizing: border-box;
+	margin: 0;
+	padding: 0;
+}
+
+body {
+	background: var(--color-bg-primary);
+	color: var(--color-text-primary);
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+	font-size: 14px;
+	line-height: 1.5;
+	overflow-x: hidden;
+}
+
+a {
+	color: var(--color-accent-primary);
+	text-decoration: none;
+}
+
+a:hover {
+	text-decoration: underline;
+}

--- a/src/test/sidepanel/components/LoginScreen.test.ts
+++ b/src/test/sidepanel/components/LoginScreen.test.ts
@@ -1,0 +1,58 @@
+import { mount, unmount } from "svelte";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { DeviceFlowController } from "../../../shared/usecase/device-flow.controller";
+import LoginScreen from "../../../sidepanel/components/LoginScreen.svelte";
+
+function createMockController(): DeviceFlowController {
+	return {
+		getState: vi.fn(() => ({ phase: "idle" as const })),
+		startFlow: vi.fn(async () => {}),
+		waitForAuthorization: vi.fn(async () => {}),
+		startAndWait: vi.fn(async () => {}),
+		subscribe: vi.fn(() => () => {}),
+	};
+}
+
+describe("LoginScreen", () => {
+	let component: ReturnType<typeof mount>;
+	let mockController: DeviceFlowController;
+
+	beforeEach(() => {
+		mockController = createMockController();
+	});
+
+	afterEach(() => {
+		if (component) {
+			unmount(component);
+		}
+		document.body.innerHTML = "";
+	});
+
+	it("should mount successfully", () => {
+		component = mount(LoginScreen, {
+			target: document.body,
+			props: { controller: mockController },
+		});
+		expect(document.body.innerHTML).not.toBe("");
+	});
+
+	it("should display login heading", () => {
+		component = mount(LoginScreen, {
+			target: document.body,
+			props: { controller: mockController },
+		});
+		const heading = document.querySelector("h2");
+		expect(heading).not.toBeNull();
+		expect(heading?.textContent).toContain("GitHub");
+	});
+
+	it("should display login button in idle state", () => {
+		component = mount(LoginScreen, {
+			target: document.body,
+			props: { controller: mockController },
+		});
+		const buttons = document.querySelectorAll("button");
+		const loginButton = Array.from(buttons).find((btn) => btn.textContent?.includes("Login"));
+		expect(loginButton).not.toBeUndefined();
+	});
+});

--- a/src/test/sidepanel/components/LogoutButton.test.ts
+++ b/src/test/sidepanel/components/LogoutButton.test.ts
@@ -1,0 +1,32 @@
+import { mount, unmount } from "svelte";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import LogoutButton from "../../../sidepanel/components/LogoutButton.svelte";
+
+describe("LogoutButton", () => {
+	let component: ReturnType<typeof mount>;
+
+	afterEach(() => {
+		if (component) {
+			unmount(component);
+		}
+		document.body.innerHTML = "";
+	});
+
+	it("should mount successfully", () => {
+		component = mount(LogoutButton, {
+			target: document.body,
+			props: { onLogout: vi.fn(async () => {}) },
+		});
+		expect(document.body.innerHTML).not.toBe("");
+	});
+
+	it("should render a logout button", () => {
+		component = mount(LogoutButton, {
+			target: document.body,
+			props: { onLogout: vi.fn(async () => {}) },
+		});
+		const button = document.querySelector("button");
+		expect(button).not.toBeNull();
+		expect(button?.textContent).toContain("Logout");
+	});
+});

--- a/src/test/sidepanel/components/MainScreen.test.ts
+++ b/src/test/sidepanel/components/MainScreen.test.ts
@@ -1,0 +1,58 @@
+import { mount, unmount } from "svelte";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ProcessedPrsResult } from "../../../domain/ports/pr-processor.port";
+import MainScreen from "../../../sidepanel/components/MainScreen.svelte";
+
+function createMockFetchPrs(): () => Promise<ProcessedPrsResult & { hasMore: boolean }> {
+	return vi.fn(async () => ({
+		myPrs: { items: [], totalCount: 0 },
+		reviewRequests: { items: [], totalCount: 0 },
+		hasMore: false,
+	}));
+}
+
+describe("MainScreen", () => {
+	let component: ReturnType<typeof mount>;
+
+	afterEach(() => {
+		if (component) {
+			unmount(component);
+		}
+		document.body.innerHTML = "";
+	});
+
+	it("should mount successfully", () => {
+		component = mount(MainScreen, {
+			target: document.body,
+			props: {
+				onLogout: vi.fn(async () => {}),
+				fetchPrs: createMockFetchPrs(),
+			},
+		});
+		expect(document.body.innerHTML).not.toBe("");
+	});
+
+	it("should display header with PR Sidebar title", () => {
+		component = mount(MainScreen, {
+			target: document.body,
+			props: {
+				onLogout: vi.fn(async () => {}),
+				fetchPrs: createMockFetchPrs(),
+			},
+		});
+		const heading = document.querySelector("h1");
+		expect(heading).not.toBeNull();
+		expect(heading?.textContent).toContain("PR Sidebar");
+	});
+
+	it("should show loading state initially", () => {
+		component = mount(MainScreen, {
+			target: document.body,
+			props: {
+				onLogout: vi.fn(async () => {}),
+				fetchPrs: createMockFetchPrs(),
+			},
+		});
+		expect(document.body.textContent).toContain("Loading");
+	});
+});

--- a/src/test/sidepanel/styles/design-tokens.test.ts
+++ b/src/test/sidepanel/styles/design-tokens.test.ts
@@ -1,0 +1,128 @@
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { beforeAll, describe, expect, it } from "vitest";
+
+describe("Design Tokens (global.css)", () => {
+	const cssPath = resolve(__dirname, "../../../sidepanel/styles/global.css");
+	let css: string;
+
+	function expectCssVariable(content: string, variableName: string): void {
+		const pattern = new RegExp(`${variableName.replace(/[-/\\^$*+?.()|[\]{}]/g, "\\$&")}\\s*:`);
+		expect(content).toMatch(pattern);
+	}
+
+	it("should have global.css file", () => {
+		expect(existsSync(cssPath)).toBe(true);
+	});
+
+	beforeAll(() => {
+		try {
+			css = readFileSync(cssPath, "utf-8");
+		} catch {
+			// File does not exist yet (RED phase). Set empty string so
+			// individual tests produce clear assertion failures instead of
+			// runtime errors on the undefined `css` variable.
+			css = "";
+		}
+	});
+
+	describe("dark theme as default", () => {
+		it("should have --color-bg-primary set to a dark color", () => {
+			const match = css.match(/--color-bg-primary\s*:\s*(#[0-9a-fA-F]{6})/);
+			expect(match).not.toBeNull();
+			if (match) {
+				const hex = match[1];
+				const r = Number.parseInt(hex.slice(1, 3), 16);
+				const g = Number.parseInt(hex.slice(3, 5), 16);
+				const b = Number.parseInt(hex.slice(5, 7), 16);
+				// Each RGB channel should be below 0x80 (128) for a dark color
+				expect(r).toBeLessThan(0x80);
+				expect(g).toBeLessThan(0x80);
+				expect(b).toBeLessThan(0x80);
+			}
+		});
+	});
+
+	describe("background color tokens", () => {
+		it("should define --color-bg-primary", () => {
+			expectCssVariable(css, "--color-bg-primary");
+		});
+
+		it("should define --color-bg-secondary", () => {
+			expectCssVariable(css, "--color-bg-secondary");
+		});
+
+		it("should define --color-bg-hover", () => {
+			expectCssVariable(css, "--color-bg-hover");
+		});
+	});
+
+	describe("text color tokens", () => {
+		it("should define --color-text-primary", () => {
+			expectCssVariable(css, "--color-text-primary");
+		});
+
+		it("should define --color-text-secondary", () => {
+			expectCssVariable(css, "--color-text-secondary");
+		});
+	});
+
+	describe("border color tokens", () => {
+		it("should define --color-border-primary", () => {
+			expectCssVariable(css, "--color-border-primary");
+		});
+	});
+
+	describe("accent color tokens", () => {
+		it("should define --color-accent-primary", () => {
+			expectCssVariable(css, "--color-accent-primary");
+		});
+	});
+
+	describe("badge color tokens", () => {
+		it("should define --color-badge-text", () => {
+			expectCssVariable(css, "--color-badge-text");
+		});
+
+		it("should define --color-badge-green", () => {
+			expectCssVariable(css, "--color-badge-green");
+		});
+
+		it("should define --color-badge-red", () => {
+			expectCssVariable(css, "--color-badge-red");
+		});
+
+		it("should define --color-badge-yellow", () => {
+			expectCssVariable(css, "--color-badge-yellow");
+		});
+
+		it("should define --color-badge-gray", () => {
+			expectCssVariable(css, "--color-badge-gray");
+		});
+	});
+
+	it("should define all 12 tokens inside :root selector", () => {
+		const rootMatch = css.match(/:root\s*\{([^}]*)\}/s);
+		expect(rootMatch).not.toBeNull();
+		if (rootMatch) {
+			const rootContent = rootMatch[1];
+			const allTokens = [
+				"--color-bg-primary",
+				"--color-bg-secondary",
+				"--color-bg-hover",
+				"--color-text-primary",
+				"--color-text-secondary",
+				"--color-border-primary",
+				"--color-accent-primary",
+				"--color-badge-text",
+				"--color-badge-green",
+				"--color-badge-red",
+				"--color-badge-yellow",
+				"--color-badge-gray",
+			];
+			for (const token of allTokens) {
+				expect(rootContent).toContain(token);
+			}
+		}
+	});
+});


### PR DESCRIPTION
## 概要
サイドパネル全体にダークテーマを適用し、CSS Variables によるデザイントークン管理を導入。全コンポーネントのハードコード色を CSS Variables に置換し、PR HUD 的なコンパクトで一覧性の高い UI を実現した。

## 変更内容
- `src/sidepanel/styles/global.css` (新規): `:root` に 12 の CSS Variables (背景・テキスト・ボーダー・アクセント・バッジ) を定義、リセット CSS、body ベーススタイル
- `src/sidepanel/main.ts`: `global.css` の import 追加
- `src/sidepanel/styles/badge.css`: ハードコード色を CSS Variables に置換 (フォールバック値付き)
- `src/sidepanel/App.svelte`: ローディング表示を中央配置の div にラップ
- `src/sidepanel/components/MainScreen.svelte`: sticky ヘッダー、ダーク配色、retry-button に hover/active フィードバック
- `src/sidepanel/components/LoginScreen.svelte`: ダーク配色、login-btn/copy-btn に hover/active フィードバック、device-flow の max-width 制約
- `src/sidepanel/components/PrItem.svelte`: hover 時の背景色変化、コンパクトなフォントサイズ・パディング
- `src/sidepanel/components/PrSection.svelte`: section-header に hover/active、toggle-icon/count のダーク配色
- `src/sidepanel/components/LogoutButton.svelte`: ダーク配色、hover でテキスト色変化
- `src/sidepanel/components/CiBadge.svelte`: prefers-reduced-motion でアニメーション無効化
- `src/test/sidepanel/styles/design-tokens.test.ts` (新規): CSS Variables の存在・ダーク値検証 (15テスト)
- `src/test/sidepanel/components/LoginScreen.test.ts` (新規): マウント・表示テスト (3テスト)
- `src/test/sidepanel/components/LogoutButton.test.ts` (新規): マウント・表示テスト (2テスト)
- `src/test/sidepanel/components/MainScreen.test.ts` (新規): マウント・表示テスト (3テスト)

## 関連 Issue
- closes #16

## テスト
- [x] TypeScript 型チェック通過 (`pnpm check`)
- [x] フロントエンドテスト通過 (`pnpm test`) — 368 テスト全パス
- [x] Rust lint 通過 (`cargo clippy --all-targets`)
- [x] Rust テスト通過 (`cargo test`)
- [x] `/verify` で検証ループ PASS

## レビュー観点
- CSS Variables の命名規則 (`--color-{category}-{variant}`) の一貫性
- ダークテーマのカラーパレット選択 (背景 `#0d1117`, テキスト `#c9d1d9` 等)
- hover/active のインタラクションフィードバックが全ボタンで統一されているか
- Chrome Side Panel の幅制約 (320-400px) でレイアウトが崩れないか
- badge.css のフォールバック値の妥当性