### PR TITLE
fix: LoginScreenのエラーメッセージを固定文字列マッピングに変更

### DIFF
--- a/src/shared/types/auth.ts
+++ b/src/shared/types/auth.ts
@@ -22,6 +22,19 @@ export type AuthErrorCode =
 	| "device_flow_expired"
 	| "device_flow_denied";
 
+const AUTH_ERROR_CODES: ReadonlySet<string> = new Set<string>([
+	"authorization_failed",
+	"token_exchange_failed",
+	"device_code_request_failed",
+	"device_code_validation_failed",
+	"device_flow_expired",
+	"device_flow_denied",
+]);
+
+export function isAuthErrorCode(code: string): code is AuthErrorCode {
+	return AUTH_ERROR_CODES.has(code);
+}
+
 export class AuthError extends Error {
 	readonly code: AuthErrorCode;
 	constructor(code: AuthErrorCode, message: string, options?: ErrorOptions) {

--- a/src/shared/usecase/auth.usecase.ts
+++ b/src/shared/usecase/auth.usecase.ts
@@ -1,5 +1,6 @@
 import type { DeviceCodeResponse, PollResult } from "../../domain/types/auth";
 import type { SendMessage } from "../ports/message.port";
+import { AuthError, isAuthErrorCode } from "../types/auth";
 import type { ResponseMessage } from "../types/messages";
 
 /** Side Panel 側のポーリング間隔下限 (秒) */
@@ -49,6 +50,9 @@ export function createAuthUseCase(sendMessage: SendMessage) {
 	async function requestDeviceCode(): Promise<DeviceCodeResponse> {
 		const response = await sendMessage("AUTH_DEVICE_CODE");
 		if (!response.ok) {
+			if (isAuthErrorCode(response.error.code)) {
+				throw new AuthError(response.error.code, response.error.message);
+			}
 			throw new Error(response.error.message);
 		}
 		return response.data;
@@ -101,18 +105,18 @@ export function createAuthUseCase(sendMessage: SendMessage) {
 						lastError = new Error(response.error.message);
 						continue;
 					}
-					// リトライ不可のエラーは即 throw
-					onStateChange?.({ phase: "error", message: response.error.message });
+					// リトライ不可のエラーは即 throw (controller の catch で toUserFacingMessage が適用される)
+					if (isAuthErrorCode(response.error.code)) {
+						throw new AuthError(response.error.code, response.error.message);
+					}
 					throw new Error(response.error.message);
 				}
 
 				return response.data;
 			}
 
-			// リトライ上限超過
-			const message = lastError?.message ?? "Unknown polling error";
-			onStateChange?.({ phase: "error", message });
-			throw lastError ?? new Error(message);
+			// リトライ上限超過 (controller の catch で toUserFacingMessage が適用される)
+			throw lastError ?? new Error("Unknown polling error");
 		}
 
 		while (Date.now() < deadline) {

--- a/src/shared/usecase/device-flow.controller.ts
+++ b/src/shared/usecase/device-flow.controller.ts
@@ -1,4 +1,22 @@
+import { AuthError, type AuthErrorCode } from "../types/auth";
 import type { DeviceFlowState, createAuthUseCase } from "./auth.usecase";
+
+const AUTH_ERROR_MESSAGES: Record<AuthErrorCode, string> = {
+	authorization_failed: "認証に失敗しました。もう一度お試しください。",
+	token_exchange_failed: "トークンの取得に失敗しました。もう一度お試しください。",
+	device_code_request_failed: "デバイスコードの取得に失敗しました。もう一度お試しください。",
+	device_code_validation_failed: "デバイスコードの検証に失敗しました。もう一度お試しください。",
+	device_flow_expired: "認証の有効期限が切れました。もう一度お試しください。",
+	device_flow_denied: "認証が拒否されました。",
+};
+const FALLBACK_ERROR_MESSAGE = "エラーが発生しました。もう一度お試しください。";
+
+function toUserFacingMessage(error: unknown): string {
+	if (error instanceof AuthError) {
+		return AUTH_ERROR_MESSAGES[error.code] ?? FALLBACK_ERROR_MESSAGE;
+	}
+	return FALLBACK_ERROR_MESSAGE;
+}
 
 export type DeviceFlowController = {
 	readonly getState: () => DeviceFlowState;
@@ -45,7 +63,7 @@ export function createDeviceFlowController(
 				verificationUri: result.verificationUri,
 			});
 		} catch (error: unknown) {
-			const message = error instanceof Error ? error.message : String(error);
+			const message = toUserFacingMessage(error);
 			setState({ phase: "error", message });
 		}
 	}
@@ -67,7 +85,7 @@ export function createDeviceFlowController(
 		} catch (error: unknown) {
 			const current = state;
 			if (current.phase !== "error" && current.phase !== "expired" && current.phase !== "denied") {
-				const message = error instanceof Error ? error.message : String(error);
+				const message = toUserFacingMessage(error);
 				setState({ phase: "error", message });
 			}
 		}

--- a/src/test/shared/usecase/auth.usecase.test.ts
+++ b/src/test/shared/usecase/auth.usecase.test.ts
@@ -182,7 +182,6 @@ describe("auth usecase", () => {
 			expect(error).toBeInstanceOf(Error);
 			expect((error as Error).message).toBe("fetch failed");
 			expect(mockSendMessage).toHaveBeenCalledTimes(3);
-			expect(onStateChange).toHaveBeenCalledWith({ phase: "error", message: "fetch failed" });
 		});
 
 		it("should retry on RUNTIME_ERROR response then succeed", async () => {
@@ -254,10 +253,6 @@ describe("auth usecase", () => {
 			expect((error as Error).message).toBe("Invalid device code");
 			// リトライなし: 1回だけ呼ばれる
 			expect(mockSendMessage).toHaveBeenCalledTimes(1);
-			expect(onStateChange).toHaveBeenCalledWith({
-				phase: "error",
-				message: "Invalid device code",
-			});
 		});
 
 		it("should expire when deadline is exceeded during retry wait", async () => {
@@ -309,10 +304,6 @@ describe("auth usecase", () => {
 			expect(error).toBeInstanceOf(Error);
 			expect((error as Error).message).toBe("Service worker restarted");
 			expect(mockSendMessage).toHaveBeenCalledTimes(3);
-			expect(onStateChange).toHaveBeenCalledWith({
-				phase: "error",
-				message: "Service worker restarted",
-			});
 		});
 	});
 

--- a/src/test/shared/usecase/device-flow.controller.test.ts
+++ b/src/test/shared/usecase/device-flow.controller.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { DeviceCodeResponse, PollResult } from "../../../domain/types/auth";
+import { AuthError } from "../../../shared/types/auth";
 import type { DeviceFlowState } from "../../../shared/usecase/auth.usecase";
 import { createDeviceFlowController } from "../../../shared/usecase/device-flow.controller";
 
@@ -54,7 +55,9 @@ describe("device-flow controller", () => {
 	});
 
 	it("startFlow() 失敗時に state が error になること", async () => {
-		mockRequestDeviceCode.mockRejectedValue(new Error("Network failure"));
+		mockRequestDeviceCode.mockRejectedValue(
+			new AuthError("device_code_request_failed", "Network failure"),
+		);
 
 		const controller = buildController();
 
@@ -62,9 +65,8 @@ describe("device-flow controller", () => {
 
 		const state = controller.getState();
 		expect(state.phase).toBe("error");
-		if (state.phase === "error") {
-			expect(state.message).toBe("Network failure");
-		}
+		const errorState = state as Extract<DeviceFlowState, { phase: "error" }>;
+		expect(errorState.message).toBe("デバイスコードの取得に失敗しました。もう一度お試しください。");
 	});
 
 	it("waitForAuthorization() が保持された deviceCode で authUseCase.waitForAuthorization を呼ぶこと", async () => {
@@ -279,9 +281,8 @@ describe("device-flow controller", () => {
 		// catch 防御により error state に遷移している
 		const state = controller.getState();
 		expect(state.phase).toBe("error");
-		if (state.phase === "error") {
-			expect(state.message).toBe("Unexpected crash");
-		}
+		const errorState = state as Extract<DeviceFlowState, { phase: "error" }>;
+		expect(errorState.message).toBe("エラーが発生しました。もう一度お試しください。");
 	});
 
 	it("catch 防御: onStateChange で expired に遷移済みの場合、error に上書きしないこと", async () => {
@@ -304,5 +305,73 @@ describe("device-flow controller", () => {
 
 		// expired のまま、error に上書きされていない
 		expect(controller.getState()).toEqual({ phase: "expired" });
+	});
+
+	it.each([
+		["authorization_failed", "認証に失敗しました。もう一度お試しください。"],
+		["token_exchange_failed", "トークンの取得に失敗しました。もう一度お試しください。"],
+		["device_code_request_failed", "デバイスコードの取得に失敗しました。もう一度お試しください。"],
+		[
+			"device_code_validation_failed",
+			"デバイスコードの検証に失敗しました。もう一度お試しください。",
+		],
+		["device_flow_expired", "認証の有効期限が切れました。もう一度お試しください。"],
+		["device_flow_denied", "認証が拒否されました。"],
+	] as const)(
+		"startFlow() で AuthError code=%s に対応する固定メッセージが表示されること",
+		async (code, expectedMessage) => {
+			mockRequestDeviceCode.mockRejectedValue(new AuthError(code, `raw: ${code}`));
+
+			const controller = buildController();
+			await controller.startFlow();
+
+			const state = controller.getState();
+			expect(state.phase).toBe("error");
+			const errorState = state as Extract<DeviceFlowState, { phase: "error" }>;
+			expect(errorState.message).toBe(expectedMessage);
+		},
+	);
+
+	it("未知の AuthError.code にフォールバックメッセージが表示されること", async () => {
+		// AuthErrorCode に存在しないコードを強制的に渡す
+		mockRequestDeviceCode.mockRejectedValue(
+			new AuthError("unknown_code" as never, "Something unknown happened"),
+		);
+
+		const controller = buildController();
+		await controller.startFlow();
+
+		const state = controller.getState();
+		expect(state.phase).toBe("error");
+		const errorState = state as Extract<DeviceFlowState, { phase: "error" }>;
+		expect(errorState.message).toBe("エラーが発生しました。もう一度お試しください。");
+	});
+
+	it("waitForAuthorization() で AuthError が throw された場合に固定メッセージが表示されること", async () => {
+		mockRequestDeviceCode.mockResolvedValue(deviceCodeResponse);
+		mockWaitForAuthorization.mockRejectedValue(
+			new AuthError("token_exchange_failed", "Raw error message"),
+		);
+
+		const controller = buildController();
+		await controller.startFlow();
+		await controller.waitForAuthorization();
+
+		const state = controller.getState();
+		expect(state.phase).toBe("error");
+		const errorState = state as Extract<DeviceFlowState, { phase: "error" }>;
+		expect(errorState.message).toBe("トークンの取得に失敗しました。もう一度お試しください。");
+	});
+
+	it("AuthError でない Error にフォールバックメッセージが表示されること", async () => {
+		mockRequestDeviceCode.mockRejectedValue(new TypeError("Cannot read properties of undefined"));
+
+		const controller = buildController();
+		await controller.startFlow();
+
+		const state = controller.getState();
+		expect(state.phase).toBe("error");
+		const errorState = state as Extract<DeviceFlowState, { phase: "error" }>;
+		expect(errorState.message).toBe("エラーが発生しました。もう一度お試しください。");
 	});
 });


### PR DESCRIPTION
## 概要

LoginScreen.svelte で `e.message` を直接 DOM に描画していた箇所を、`AuthError.code` ベースの固定文字列テーブルからメッセージを取得する方式に変更し、外部由来文字列の UI 注入リスクを排除する。

## 変更内容

- `src/shared/types/auth.ts`: `isAuthErrorCode` 型ガード関数と `AUTH_ERROR_CODES` Set を追加
- `src/shared/usecase/auth.usecase.ts`: `throw new Error(response.error.message)` を `isAuthErrorCode` ガード付き `AuthError` throw に変更。`onStateChange` での生メッセージ直接渡しを削除
- `src/shared/usecase/device-flow.controller.ts`: `AUTH_ERROR_MESSAGES` 固定文字列マッピングテーブルと `toUserFacingMessage` 関数を追加。catch ブロックで固定文字列に変換
- `src/test/shared/usecase/auth.usecase.test.ts`: `onStateChange` の生メッセージ assert を削除
- `src/test/shared/usecase/device-flow.controller.test.ts`: 全 AuthErrorCode の固定メッセージテスト、未知コードフォールバック、非 AuthError フォールバック、waitForAuthorization 経路のテストを追加

## 関連 Issue

- closes #130

## テスト

- [x] TypeScript 型チェック通過 (`pnpm check`)
- [x] フロントエンドテスト通過 (`pnpm test`) — 354 PASS
- [x] Rust lint 通過 (`cargo clippy --all-targets`)
- [x] Rust テスト通過 (`cargo test`) — 36 PASS
- [x] `/verify` で検証ループ PASS

## レビュー観点

- `auth.usecase.ts` から `onStateChange({ phase: "error", ... })` を削除した設計判断: controller の catch に一本化することで、外部文字列が UI に到達する経路を完全に遮断
- `isAuthErrorCode` バリデーション: `response.error.code` が `AuthErrorCode` に合致しない場合は素の `Error` を throw し、controller で `FALLBACK_ERROR_MESSAGE` にフォールバック
- `AUTH_ERROR_CODES` Set と `AuthErrorCode` 型の二重管理: 将来的に `as const` パターンで単一ソース化可能（LOW 残存指摘）

https://claude.ai/code/session_01RM6ejk1WjU2Gn7LoMCesSV