### PR TITLE
feat: PR一覧にAuthor名を表示する

### DIFF
--- a/src/sidepanel/components/PrItem.svelte
+++ b/src/sidepanel/components/PrItem.svelte
@@ -18,6 +18,7 @@
 		#{pr.number} {pr.title}
 	</a>
 	<div class="pr-meta">
+		<span class="pr-author">{pr.author}</span>
 		<span class="pr-repo">{pr.repository}</span>
 		<span class="pr-updated">{formatRelativeTime(pr.updatedAt)}</span>
 	</div>
@@ -59,6 +60,14 @@
 		font-size: 0.6875rem;
 		color: var(--color-text-secondary);
 		margin-top: 0.125rem;
+	}
+
+	.pr-author {
+		max-width: 7rem;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+		flex-shrink: 0;
 	}
 
 	.pr-badges {

--- a/src/test/sidepanel/components/PrItem.test.ts
+++ b/src/test/sidepanel/components/PrItem.test.ts
@@ -1,0 +1,75 @@
+import { mount, unmount } from "svelte";
+import { afterEach, describe, expect, it } from "vitest";
+import type { PrItemDto } from "../../../domain/ports/pr-processor.port";
+import PrItem from "../../../sidepanel/components/PrItem.svelte";
+
+function createPrItemDto(overrides: Partial<PrItemDto> = {}): PrItemDto {
+	return {
+		id: "PR_123",
+		number: 42,
+		title: "Add feature X",
+		author: "octocat",
+		url: "https://github.com/owner/repo/pull/42",
+		repository: "owner/repo",
+		isDraft: false,
+		approvalStatus: "ReviewRequired",
+		ciStatus: "Passed",
+		additions: 10,
+		deletions: 3,
+		createdAt: "2026-03-20T10:00:00Z",
+		updatedAt: "2026-03-23T10:00:00Z",
+		...overrides,
+	};
+}
+
+describe("PrItem", () => {
+	let component: ReturnType<typeof mount>;
+
+	afterEach(() => {
+		if (component) {
+			unmount(component);
+		}
+		document.body.innerHTML = "";
+	});
+
+	it("should display the author name in a .pr-author element", () => {
+		component = mount(PrItem, {
+			target: document.body,
+			props: { pr: createPrItemDto({ author: "testuser" }) },
+		});
+		const authorEl = document.querySelector(".pr-author");
+		expect(authorEl).not.toBeNull();
+		expect(authorEl?.textContent?.trim()).toBe("testuser");
+	});
+
+	it("should display the PR number and title", () => {
+		component = mount(PrItem, {
+			target: document.body,
+			props: { pr: createPrItemDto({ number: 99, title: "Fix bug Y" }) },
+		});
+		const titleEl = document.querySelector(".pr-title");
+		expect(titleEl).not.toBeNull();
+		expect(titleEl?.textContent?.trim()).toBe("#99 Fix bug Y");
+	});
+
+	it("should display the repository name", () => {
+		component = mount(PrItem, {
+			target: document.body,
+			props: { pr: createPrItemDto({ repository: "myorg/myrepo" }) },
+		});
+		const repoEl = document.querySelector(".pr-repo");
+		expect(repoEl).not.toBeNull();
+		expect(repoEl?.textContent?.trim()).toBe("myorg/myrepo");
+	});
+
+	it("should render long author name inside .pr-author element for CSS truncation", () => {
+		const longName = "a-very-long-github-username-that-might-overflow";
+		component = mount(PrItem, {
+			target: document.body,
+			props: { pr: createPrItemDto({ author: longName }) },
+		});
+		const authorEl = document.querySelector(".pr-author");
+		expect(authorEl).not.toBeNull();
+		expect(authorEl?.textContent?.trim()).toBe(longName);
+	});
+});


### PR DESCRIPTION
## 概要
PR一覧の各行にAuthor名を表示し、誰が出したPRかを一目で確認できるようにした。PrItem コンポーネントの `.pr-meta` 内に author 名を追加し、CSS truncate で長い名前にも対応。

## 変更内容
- `src/sidepanel/components/PrItem.svelte`: `.pr-meta` div 内に `<span class="pr-author">{pr.author}</span>` を追加。CSS truncate (max-width: 7rem, text-overflow: ellipsis) を設定
- `src/test/sidepanel/components/PrItem.test.ts`: PrItem コンポーネントのユニットテストを新規作成 (author 表示、PR番号・タイトル表示、リポジトリ名表示、長い名前の truncate 対応)

## 関連 Issue
- closes #154

## テスト
- [x] TypeScript 型チェック通過 (`pnpm check`)
- [x] フロントエンドテスト通過 (`pnpm test`) — 426 passed
- [x] Rust lint 通過 (`cargo clippy --all-targets`)
- [x] Rust テスト通過 (`cargo test`) — 36 passed
- [x] `/verify` で検証ループ PASS

## レビュー観点
- author 名の表示位置 (repo 名の前) が UX として適切か
- CSS truncate の max-width: 7rem がサイドパネル幅に対して適切か
- 既存レビューで Issue 化した #158 (削除済みユーザーの null author) と #159 (formatRelativeTime 責務境界) の優先度判断