### PR TITLE
feat: Review Requestがある時に拡張アイコンにバッジを表示する

### DIFF
--- a/src/adapter/chrome/badge.adapter.ts
+++ b/src/adapter/chrome/badge.adapter.ts
@@ -1,0 +1,12 @@
+import type { BadgePort } from "../../domain/ports/badge.port";
+
+export function createChromeBadgeAdapter(): BadgePort {
+	return {
+		async setBadgeText(text: string): Promise<void> {
+			await chrome.action.setBadgeText({ text });
+		},
+		async setBadgeBackgroundColor(color: string): Promise<void> {
+			await chrome.action.setBadgeBackgroundColor({ color });
+		},
+	};
+}

--- a/src/background/bootstrap.ts
+++ b/src/background/bootstrap.ts
@@ -1,10 +1,12 @@
 import { ChromeAlarmAdapter } from "../adapter/chrome/alarm.adapter";
+import { createChromeBadgeAdapter } from "../adapter/chrome/badge.adapter";
 import { ChromeIdentityAdapter } from "../adapter/chrome/identity.adapter";
 import { createOAuthConfig } from "../adapter/chrome/oauth.config";
 import { ChromeStorageAdapter } from "../adapter/chrome/storage.adapter";
 import { GitHubGraphQLClient } from "../adapter/github/graphql-client";
 import { GitHubApiError } from "../shared/types/errors";
 import { createAutoRefreshUseCase } from "../shared/usecase/auto-refresh.usecase";
+import { createBadgeUseCase } from "../shared/usecase/badge.usecase";
 import { WasmPrProcessor } from "../wasm/pr-processor";
 import { createMessageHandler } from "./message-handler";
 import type { AppServices } from "./types";
@@ -30,7 +32,11 @@ export function initializeApp(): AppServices {
 		}
 		return token.accessToken;
 	});
-	const handler = createMessageHandler({ auth, githubApi });
+
+	const badgeAdapter = createChromeBadgeAdapter();
+	const badge = createBadgeUseCase(badgeAdapter);
+
+	const handler = createMessageHandler({ auth, githubApi, badge });
 	chrome.runtime.onMessage.addListener(handler);
 
 	const alarm = new ChromeAlarmAdapter();
@@ -42,6 +48,13 @@ export function initializeApp(): AppServices {
 			const raw = await githubApi.fetchPullRequests();
 			const processed = await prProcessor.processPullRequests(raw.rawJson, "@me");
 			return { ...processed, hasMore: raw.hasMore };
+		},
+		onRefreshComplete: (data) => {
+			badge.updateBadge(data.reviewRequests.totalCount).catch((err: unknown) => {
+				if (import.meta.env.DEV) {
+					console.error("[bootstrap] Failed to update badge:", err);
+				}
+			});
 		},
 	});
 	autoRefresh.start().catch((err: unknown) => {
@@ -67,6 +80,6 @@ export function initializeApp(): AppServices {
 		}
 	};
 
-	services = { auth, githubApi, dispose };
+	services = { auth, githubApi, badge, dispose };
 	return services;
 }

--- a/src/background/message-handler.ts
+++ b/src/background/message-handler.ts
@@ -9,13 +9,14 @@ const ERROR_MESSAGES: Record<MessageType, string> = {
 	AUTH_DEVICE_CODE: "Device code request failed",
 	AUTH_DEVICE_POLL: "Device polling failed",
 	FETCH_PRS: "Failed to fetch pull requests",
+	UPDATE_BADGE: "Failed to update badge",
 };
 
 /** deviceCode の長さ制限 */
 const DEVICE_CODE_MIN_LENGTH = 8;
 const DEVICE_CODE_MAX_LENGTH = 256;
 
-export function createMessageHandler(services: Pick<AppServices, "auth" | "githubApi">) {
+export function createMessageHandler(services: Pick<AppServices, "auth" | "githubApi" | "badge">) {
 	return (
 		message: unknown,
 		sender: chrome.runtime.MessageSender,
@@ -36,7 +37,7 @@ export function createMessageHandler(services: Pick<AppServices, "auth" | "githu
 }
 
 async function handleMessage(
-	services: Pick<AppServices, "auth" | "githubApi">,
+	services: Pick<AppServices, "auth" | "githubApi" | "badge">,
 	message: RequestMessage<MessageType>,
 	sendResponse: (response: ResponseMessage<MessageType>) => void,
 ): Promise<void> {
@@ -80,6 +81,23 @@ async function handleMessage(
 			case "FETCH_PRS": {
 				const result = await services.githubApi.fetchPullRequests();
 				sendResponse({ ok: true, data: result });
+				break;
+			}
+			case "UPDATE_BADGE": {
+				// 将来 sidepanel からの手動更新用に予約。現在の主経路は bootstrap.ts の onRefreshComplete コールバック
+				const msg = message as RequestMessage<"UPDATE_BADGE">;
+				const { reviewRequestCount } = msg.payload;
+
+				if (!Number.isInteger(reviewRequestCount) || reviewRequestCount < 0) {
+					sendResponse({
+						ok: false,
+						error: { code: "UPDATE_BADGE_ERROR", message: "Invalid review request count" },
+					});
+					break;
+				}
+
+				await services.badge.updateBadge(reviewRequestCount);
+				sendResponse({ ok: true, data: undefined });
 				break;
 			}
 			default: {

--- a/src/background/types.ts
+++ b/src/background/types.ts
@@ -1,8 +1,13 @@
 import type { AuthPort } from "../domain/ports/auth.port";
 import type { GitHubApiPort } from "../domain/ports/github-api.port";
 
+export type BadgeService = {
+	readonly updateBadge: (reviewRequestCount: number) => Promise<void>;
+};
+
 export type AppServices = {
 	readonly auth: AuthPort;
 	readonly githubApi: GitHubApiPort;
+	readonly badge: BadgeService;
 	readonly dispose: () => void;
 };

--- a/src/domain/ports/badge.port.ts
+++ b/src/domain/ports/badge.port.ts
@@ -1,0 +1,4 @@
+export interface BadgePort {
+	setBadgeText(text: string): Promise<void>;
+	setBadgeBackgroundColor(color: string): Promise<void>;
+}

--- a/src/shared/types/messages.ts
+++ b/src/shared/types/messages.ts
@@ -7,6 +7,7 @@ export const MESSAGE_TYPES = [
 	"AUTH_DEVICE_CODE",
 	"AUTH_DEVICE_POLL",
 	"FETCH_PRS",
+	"UPDATE_BADGE",
 ] as const;
 
 export type MessageType = (typeof MESSAGE_TYPES)[number];
@@ -18,6 +19,7 @@ export type RequestMap = {
 	AUTH_DEVICE_CODE: undefined;
 	AUTH_DEVICE_POLL: { deviceCode: string };
 	FETCH_PRS: undefined;
+	UPDATE_BADGE: { reviewRequestCount: number };
 };
 
 /** メッセージタイプ → レスポンスデータのマッピング */
@@ -27,6 +29,7 @@ export type ResponseDataMap = {
 	AUTH_DEVICE_CODE: DeviceCodeResponse;
 	AUTH_DEVICE_POLL: PollResult;
 	FETCH_PRS: FetchRawPullRequestsResult;
+	UPDATE_BADGE: undefined;
 };
 
 export type MessageError = {

--- a/src/shared/usecase/auto-refresh.usecase.ts
+++ b/src/shared/usecase/auto-refresh.usecase.ts
@@ -7,6 +7,8 @@ type AutoRefreshDeps = {
 	readonly alarm: AlarmPort;
 	readonly storage: StoragePort;
 	readonly fetchAndProcessPrs: () => Promise<ProcessedPrsResult & { hasMore: boolean }>;
+	/** 非同期処理が必要な場合は呼び出し側で .catch() すること（同期例外のみ捕捉される） */
+	readonly onRefreshComplete?: (data: ProcessedPrsResult & { hasMore: boolean }) => void;
 };
 
 export function createAutoRefreshUseCase(deps: AutoRefreshDeps) {
@@ -51,6 +53,15 @@ export function createAutoRefreshUseCase(deps: AutoRefreshDeps) {
 			data,
 			lastUpdatedAt: new Date().toISOString(),
 		});
+		if (deps.onRefreshComplete) {
+			try {
+				deps.onRefreshComplete(data);
+			} catch (err: unknown) {
+				if (import.meta.env.DEV) {
+					console.error("[auto-refresh] onRefreshComplete callback error:", err);
+				}
+			}
+		}
 	}
 
 	async function getCachedPrs(): Promise<CachedPrData | null> {

--- a/src/shared/usecase/badge.usecase.ts
+++ b/src/shared/usecase/badge.usecase.ts
@@ -1,0 +1,25 @@
+import type { BadgePort } from "../../domain/ports/badge.port";
+
+const BADGE_COLOR = "#1976D2";
+const MAX_DISPLAY_COUNT = 99;
+
+export function createBadgeUseCase(badge: BadgePort): {
+	updateBadge(reviewRequestCount: number): Promise<void>;
+} {
+	async function updateBadge(reviewRequestCount: number): Promise<void> {
+		if (!Number.isFinite(reviewRequestCount) || reviewRequestCount < 0) {
+			await badge.setBadgeText("");
+			return;
+		}
+		const count = Math.floor(reviewRequestCount);
+		if (count === 0) {
+			await badge.setBadgeText("");
+			return;
+		}
+		const text = count > MAX_DISPLAY_COUNT ? "99+" : String(count);
+		await badge.setBadgeBackgroundColor(BADGE_COLOR);
+		await badge.setBadgeText(text);
+	}
+
+	return { updateBadge };
+}

--- a/src/test/adapter/chrome/badge.adapter.test.ts
+++ b/src/test/adapter/chrome/badge.adapter.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createChromeBadgeAdapter } from "../../../adapter/chrome/badge.adapter";
+import type { BadgePort } from "../../../domain/ports/badge.port";
+import { getChromeMock, resetChromeMock, setupChromeMock } from "../../mocks/chrome.mock";
+
+describe("ChromeBadgeAdapter", () => {
+	let adapter: BadgePort;
+
+	beforeEach(() => {
+		setupChromeMock();
+		adapter = createChromeBadgeAdapter();
+	});
+
+	afterEach(() => {
+		resetChromeMock();
+	});
+
+	describe("setBadgeText", () => {
+		it("should call chrome.action.setBadgeText with correct text", async () => {
+			await adapter.setBadgeText("3");
+
+			const mock = getChromeMock();
+			expect(mock.action.setBadgeText).toHaveBeenCalledWith({ text: "3" });
+		});
+
+		it("should call chrome.action.setBadgeText with empty string to clear badge", async () => {
+			await adapter.setBadgeText("");
+
+			const mock = getChromeMock();
+			expect(mock.action.setBadgeText).toHaveBeenCalledWith({ text: "" });
+		});
+	});
+
+	describe("setBadgeBackgroundColor", () => {
+		it("should call chrome.action.setBadgeBackgroundColor with correct color", async () => {
+			await adapter.setBadgeBackgroundColor("#FF0000");
+
+			const mock = getChromeMock();
+			expect(mock.action.setBadgeBackgroundColor).toHaveBeenCalledWith({ color: "#FF0000" });
+		});
+	});
+});

--- a/src/test/background/message-handler.test.ts
+++ b/src/test/background/message-handler.test.ts
@@ -277,4 +277,86 @@ describe("createMessageHandler", () => {
 			expect(response).not.toHaveProperty("data.accessToken");
 		});
 	});
+
+	describe("UPDATE_BADGE", () => {
+		let mockBadge: { updateBadge: ReturnType<typeof vi.fn> };
+
+		beforeEach(() => {
+			mockBadge = { updateBadge: vi.fn().mockResolvedValue(undefined) };
+			// badge は未実装のフィールド。RED フェーズでは型定義を変更しないため cast で追加する
+			services = { auth: mockAuth, badge: mockBadge } as unknown as AppServices;
+			handler = createMessageHandler(services);
+		});
+
+		// NOTE: RED フェーズでは MESSAGE_TYPES に UPDATE_BADGE がないため isRequestMessage で弾かれタイムアウトで失敗する。GREEN フェーズで MESSAGE_TYPES 拡張後に正しい理由で失敗→通過する
+		it("should call badge.updateBadge with reviewRequestCount", async () => {
+			const sendResponse = vi.fn();
+
+			handler(
+				{ type: "UPDATE_BADGE", payload: { reviewRequestCount: 3 } },
+				createTrustedSender(),
+				sendResponse,
+			);
+
+			await vi.waitFor(() => {
+				expect(sendResponse).toHaveBeenCalled();
+			});
+
+			expect(mockBadge.updateBadge).toHaveBeenCalledWith(3);
+			const response = sendResponse.mock.calls[0][0];
+			expect(response).toEqual({ ok: true, data: undefined });
+		});
+
+		// NOTE: RED フェーズでは MESSAGE_TYPES に UPDATE_BADGE がないため isRequestMessage で弾かれタイムアウトで失敗する。GREEN フェーズで MESSAGE_TYPES 拡張後に正しい理由で失敗→通過する
+		it("should respond with error when badge.updateBadge throws", async () => {
+			mockBadge.updateBadge.mockRejectedValue(new Error("Badge update failed"));
+			const sendResponse = vi.fn();
+
+			handler(
+				{ type: "UPDATE_BADGE", payload: { reviewRequestCount: 5 } },
+				createTrustedSender(),
+				sendResponse,
+			);
+
+			await vi.waitFor(() => {
+				expect(sendResponse).toHaveBeenCalled();
+			});
+
+			const response = sendResponse.mock.calls[0][0];
+			expect(response.ok).toBe(false);
+			expect(response.error.code).toBe("UPDATE_BADGE_ERROR");
+		});
+
+		// NOTE: RED フェーズでは MESSAGE_TYPES に UPDATE_BADGE がないため isRequestMessage で弾かれタイムアウトで失敗する。GREEN フェーズで MESSAGE_TYPES 拡張後に正しい理由で失敗→通過する
+		it("should respond with error when reviewRequestCount is negative", async () => {
+			const sendResponse = vi.fn();
+
+			handler(
+				{ type: "UPDATE_BADGE", payload: { reviewRequestCount: -1 } },
+				createTrustedSender(),
+				sendResponse,
+			);
+
+			await vi.waitFor(() => {
+				expect(sendResponse).toHaveBeenCalled();
+			});
+
+			const response = sendResponse.mock.calls[0][0];
+			expect(response.ok).toBe(false);
+		});
+
+		// NOTE: RED フェーズでは MESSAGE_TYPES に UPDATE_BADGE がないため isRequestMessage で弾かれタイムアウトで失敗する。GREEN フェーズで MESSAGE_TYPES 拡張後に正しい理由で失敗→通過する
+		it("should respond with error when payload is missing", async () => {
+			const sendResponse = vi.fn();
+
+			handler({ type: "UPDATE_BADGE" }, createTrustedSender(), sendResponse);
+
+			await vi.waitFor(() => {
+				expect(sendResponse).toHaveBeenCalled();
+			});
+
+			const response = sendResponse.mock.calls[0][0];
+			expect(response.ok).toBe(false);
+		});
+	});
 });

--- a/src/test/mocks/chrome.mock.ts
+++ b/src/test/mocks/chrome.mock.ts
@@ -37,6 +37,10 @@ type ChromeMock = {
 			removeListener: ReturnType<typeof vi.fn>;
 		};
 	};
+	action: {
+		setBadgeText: ReturnType<typeof vi.fn>;
+		setBadgeBackgroundColor: ReturnType<typeof vi.fn>;
+	};
 };
 
 let chromeMock: ChromeMock;
@@ -78,6 +82,10 @@ function createChromeMock(): ChromeMock {
 				addListener: vi.fn(),
 				removeListener: vi.fn(),
 			},
+		},
+		action: {
+			setBadgeText: vi.fn(),
+			setBadgeBackgroundColor: vi.fn(),
 		},
 	};
 }

--- a/src/test/shared/types/messages.test.ts
+++ b/src/test/shared/types/messages.test.ts
@@ -9,7 +9,8 @@ describe("messages", () => {
 			expect(MESSAGE_TYPES).toContain("AUTH_DEVICE_CODE");
 			expect(MESSAGE_TYPES).toContain("AUTH_DEVICE_POLL");
 			expect(MESSAGE_TYPES).toContain("FETCH_PRS");
-			expect(MESSAGE_TYPES).toHaveLength(5);
+			expect(MESSAGE_TYPES).toContain("UPDATE_BADGE");
+			expect(MESSAGE_TYPES).toHaveLength(6);
 		});
 	});
 

--- a/src/test/shared/usecase/auto-refresh.usecase.test.ts
+++ b/src/test/shared/usecase/auto-refresh.usecase.test.ts
@@ -184,6 +184,53 @@ describe("auto-refresh usecase", () => {
 		});
 	});
 
+	describe("onRefreshComplete callback", () => {
+		function createUseCaseWithCallback(
+			onRefreshComplete: (data: ProcessedPrsResult & { hasMore: boolean }) => void,
+		) {
+			// onRefreshComplete は未実装のフィールド。RED フェーズでは型定義を変更しないため cast で渡す
+			const deps = {
+				alarm: mockAlarm,
+				storage: mockStorage,
+				fetchAndProcessPrs: mockFetchAndProcessPrs,
+				onRefreshComplete,
+			} as Parameters<typeof createAutoRefreshUseCase>[0];
+			return createAutoRefreshUseCase(deps);
+		}
+
+		it("should call onRefreshComplete with fetched data after successful refresh", async () => {
+			const onRefreshComplete = vi.fn();
+			const useCase = createUseCaseWithCallback(onRefreshComplete);
+			await useCase.refresh();
+
+			expect(onRefreshComplete).toHaveBeenCalledWith(mockProcessedResult);
+		});
+
+		it("should not call onRefreshComplete when fetch fails", async () => {
+			mockFetchAndProcessPrs.mockRejectedValue(new Error("API error"));
+			const onRefreshComplete = vi.fn();
+			const useCase = createUseCaseWithCallback(onRefreshComplete);
+
+			await expect(useCase.refresh()).rejects.toThrow("API error");
+			expect(onRefreshComplete).not.toHaveBeenCalled();
+		});
+
+		it("should not throw when onRefreshComplete is not provided", async () => {
+			const useCase = createUseCase();
+			await expect(useCase.refresh()).resolves.not.toThrow();
+		});
+
+		it("should not propagate error when onRefreshComplete throws", async () => {
+			const onRefreshComplete = vi.fn().mockImplementation(() => {
+				throw new Error("Callback explosion");
+			});
+			const useCase = createUseCaseWithCallback(onRefreshComplete);
+
+			await expect(useCase.refresh()).resolves.not.toThrow();
+			expect(onRefreshComplete).toHaveBeenCalledWith(mockProcessedResult);
+		});
+	});
+
 	describe("alarm trigger", () => {
 		it("should call refresh when the pr-refresh alarm fires", async () => {
 			const useCase = createUseCase();

--- a/src/test/shared/usecase/badge.usecase.test.ts
+++ b/src/test/shared/usecase/badge.usecase.test.ts
@@ -1,0 +1,121 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { BadgePort } from "../../../domain/ports/badge.port";
+import { createBadgeUseCase } from "../../../shared/usecase/badge.usecase";
+
+describe("badge usecase", () => {
+	let mockBadge: {
+		[K in keyof BadgePort]: ReturnType<typeof vi.fn>;
+	};
+
+	beforeEach(() => {
+		mockBadge = {
+			setBadgeText: vi.fn().mockResolvedValue(undefined),
+			setBadgeBackgroundColor: vi.fn().mockResolvedValue(undefined),
+		};
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	describe("updateBadge", () => {
+		it("should set badge text to empty string when reviewRequestCount is 0", async () => {
+			const useCase = createBadgeUseCase(mockBadge);
+			await useCase.updateBadge(0);
+
+			expect(mockBadge.setBadgeText).toHaveBeenCalledWith("");
+		});
+
+		it("should not set badge background color when reviewRequestCount is 0", async () => {
+			const useCase = createBadgeUseCase(mockBadge);
+			await useCase.updateBadge(0);
+
+			expect(mockBadge.setBadgeBackgroundColor).not.toHaveBeenCalled();
+		});
+
+		it('should set badge text to "1" when reviewRequestCount is 1', async () => {
+			const useCase = createBadgeUseCase(mockBadge);
+			await useCase.updateBadge(1);
+
+			expect(mockBadge.setBadgeText).toHaveBeenCalledWith("1");
+		});
+
+		it('should set badge text to "99" when reviewRequestCount is 99', async () => {
+			const useCase = createBadgeUseCase(mockBadge);
+			await useCase.updateBadge(99);
+
+			expect(mockBadge.setBadgeText).toHaveBeenCalledWith("99");
+		});
+
+		it('should set badge text to "99+" when reviewRequestCount is 100 or more', async () => {
+			const useCase = createBadgeUseCase(mockBadge);
+			await useCase.updateBadge(100);
+
+			expect(mockBadge.setBadgeText).toHaveBeenCalledWith("99+");
+		});
+
+		it('should set badge text to "99+" when reviewRequestCount is 999', async () => {
+			const useCase = createBadgeUseCase(mockBadge);
+			await useCase.updateBadge(999);
+
+			expect(mockBadge.setBadgeText).toHaveBeenCalledWith("99+");
+		});
+
+		it("should set badge background color when reviewRequestCount is greater than 0", async () => {
+			const useCase = createBadgeUseCase(mockBadge);
+			await useCase.updateBadge(5);
+
+			expect(mockBadge.setBadgeBackgroundColor).toHaveBeenCalledWith(
+				expect.stringMatching(/^#[0-9A-Fa-f]{6}$/),
+			);
+		});
+
+		it("should treat negative count as 0 (clear badge)", async () => {
+			const useCase = createBadgeUseCase(mockBadge);
+			await useCase.updateBadge(-1);
+
+			expect(mockBadge.setBadgeText).toHaveBeenCalledWith("");
+			expect(mockBadge.setBadgeBackgroundColor).not.toHaveBeenCalled();
+		});
+
+		it("should clear badge when reviewRequestCount is NaN", async () => {
+			const useCase = createBadgeUseCase(mockBadge);
+			await useCase.updateBadge(Number.NaN);
+
+			expect(mockBadge.setBadgeText).toHaveBeenCalledWith("");
+			expect(mockBadge.setBadgeBackgroundColor).not.toHaveBeenCalled();
+		});
+
+		it("should clear badge when reviewRequestCount is Infinity", async () => {
+			const useCase = createBadgeUseCase(mockBadge);
+			await useCase.updateBadge(Number.POSITIVE_INFINITY);
+
+			expect(mockBadge.setBadgeText).toHaveBeenCalledWith("");
+			expect(mockBadge.setBadgeBackgroundColor).not.toHaveBeenCalled();
+		});
+
+		it("should floor non-integer counts", async () => {
+			const useCase = createBadgeUseCase(mockBadge);
+			await useCase.updateBadge(3.7);
+
+			expect(mockBadge.setBadgeText).toHaveBeenCalledWith("3");
+		});
+
+		it("should set background color before badge text when count > 0", async () => {
+			const callOrder: string[] = [];
+			mockBadge.setBadgeBackgroundColor.mockImplementation(() => {
+				callOrder.push("setBadgeBackgroundColor");
+				return Promise.resolve();
+			});
+			mockBadge.setBadgeText.mockImplementation(() => {
+				callOrder.push("setBadgeText");
+				return Promise.resolve();
+			});
+
+			const useCase = createBadgeUseCase(mockBadge);
+			await useCase.updateBadge(5);
+
+			expect(callOrder).toEqual(["setBadgeBackgroundColor", "setBadgeText"]);
+		});
+	});
+});


### PR DESCRIPTION
## 概要
Open な Review Request が存在する場合、Chrome拡張のツールバーアイコンにバッジ（件数）を表示する機能を追加。サイドパネルを開かなくても未対応のレビューがあることにアイコンで気づける。

## 変更内容
- `src/domain/ports/badge.port.ts`: BadgePort インターフェース定義
- `src/adapter/chrome/badge.adapter.ts`: chrome.action API のアダプタ実装
- `src/shared/usecase/badge.usecase.ts`: バッジ更新ロジック（99+上限、NaN/Infinity防御）
- `src/shared/types/messages.ts`: UPDATE_BADGE メッセージタイプ追加
- `src/background/message-handler.ts`: UPDATE_BADGE ハンドラ追加
- `src/background/types.ts`: BadgeService 型を AppServices に追加
- `src/shared/usecase/auto-refresh.usecase.ts`: onRefreshComplete コールバック追加
- `src/background/bootstrap.ts`: ワイヤリングとバッジ自動更新
- `src/test/mocks/chrome.mock.ts`: action モック追加

## 関連 Issue
- closes #157

## テスト
- [x] TypeScript 型チェック通過 (`pnpm check`)
- [x] フロントエンドテスト通過 (`pnpm test`) — 445テスト全PASS
- [x] Rust lint 通過 (`cargo clippy --all-targets`)
- [x] Rust テスト通過 (`cargo test`)
- [x] `/verify` で検証ループ PASS

## レビュー観点
- `badge.usecase.ts` の NaN/Infinity/負数防御ロジックが適切か
- `onRefreshComplete` コールバックのエラーハンドリング（同期例外のみ捕捉、非同期は呼び出し側で .catch()）
- `UPDATE_BADGE` メッセージハンドラは将来の sidepanel からの手動更新用に予約