### PR TITLE
fix: 相対時刻表示を定期的に更新する RelativeTime コンポーネントを追加

### DIFF
--- a/src/shared/stores/relative-time-tick.svelte.ts
+++ b/src/shared/stores/relative-time-tick.svelte.ts
@@ -1,0 +1,34 @@
+let tick = $state(0);
+let subscriberCount = 0;
+let intervalId: ReturnType<typeof setInterval> | undefined;
+
+function startTimer(): void {
+	if (intervalId === undefined) {
+		intervalId = setInterval(() => {
+			tick += 1;
+		}, 30_000);
+	}
+}
+
+function stopTimer(): void {
+	if (intervalId !== undefined) {
+		clearInterval(intervalId);
+		intervalId = undefined;
+	}
+}
+
+export function subscribe(): { get tick(): number; unsubscribe: () => void } {
+	subscriberCount += 1;
+	startTimer();
+	return {
+		get tick() {
+			return tick;
+		},
+		unsubscribe() {
+			subscriberCount -= 1;
+			if (subscriberCount === 0) {
+				stopTimer();
+			}
+		},
+	};
+}

--- a/src/sidepanel/components/MainScreen.svelte
+++ b/src/sidepanel/components/MainScreen.svelte
@@ -2,8 +2,8 @@
 	import { untrack } from "svelte";
 	import type { ProcessedPrsResult } from "../../domain/ports/pr-processor.port";
 	import type { CachedPrData } from "../../shared/types/cache";
-	import { formatRelativeTime } from "../../shared/utils/time";
 	import LogoutButton from "./LogoutButton.svelte";
+	import RelativeTime from "./RelativeTime.svelte";
 	import PrSection from "./PrSection.svelte";
 
 	type Props = {
@@ -94,7 +94,7 @@
 		</div>
 		<div class="header-right">
 			{#if lastUpdatedAt}
-				<span class="last-updated">{formatRelativeTime(lastUpdatedAt)}</span>
+				<span class="last-updated"><RelativeTime dateStr={lastUpdatedAt} /></span>
 			{/if}
 			<LogoutButton {onLogout} />
 		</div>

--- a/src/sidepanel/components/PrItem.svelte
+++ b/src/sidepanel/components/PrItem.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
 	import type { PrItemDto } from "../../domain/ports/pr-processor.port";
-	import { formatRelativeTime } from "../../shared/utils/time";
 	import { safeUrl } from "../../shared/utils/url";
 	import ApprovalBadge from "./ApprovalBadge.svelte";
 	import CiBadge from "./CiBadge.svelte";
 	import DraftBadge from "./DraftBadge.svelte";
+	import RelativeTime from "./RelativeTime.svelte";
 
 	type Props = {
 		pr: PrItemDto;
@@ -19,7 +19,7 @@
 	</a>
 	<div class="pr-meta">
 		<span class="pr-repo">{pr.repository}</span>
-		<span class="pr-updated">{formatRelativeTime(pr.updatedAt)}</span>
+		<span class="pr-updated"><RelativeTime dateStr={pr.updatedAt} /></span>
 	</div>
 	<div class="pr-badges">
 		<DraftBadge isDraft={pr.isDraft} />

--- a/src/sidepanel/components/RelativeTime.svelte
+++ b/src/sidepanel/components/RelativeTime.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+	import { formatRelativeTime } from "../../shared/utils/time";
+	import { subscribe } from "../../shared/stores/relative-time-tick.svelte";
+
+	type Props = {
+		dateStr: string;
+	};
+
+	const { dateStr }: Props = $props();
+
+	const timer = subscribe();
+
+	const display = $derived.by(() => {
+		void timer.tick;
+		return formatRelativeTime(dateStr);
+	});
+
+	$effect.pre(() => {
+		return () => timer.unsubscribe();
+	});
+</script>
+
+<span>{display}</span>

--- a/src/test/shared/stores/relative-time-tick.svelte.test.ts
+++ b/src/test/shared/stores/relative-time-tick.svelte.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { subscribe } from "../../../shared/stores/relative-time-tick.svelte";
+
+describe("relative-time-tick shared timer", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it("should start timer on first subscribe and return a numeric tick", () => {
+		const sub = subscribe();
+		expect(typeof sub.tick).toBe("number");
+		sub.unsubscribe();
+	});
+
+	it("should increment tick after 30 seconds", () => {
+		const sub = subscribe();
+		const initialTick = sub.tick;
+
+		vi.advanceTimersByTime(30_000);
+		expect(sub.tick).toBe(initialTick + 1);
+
+		vi.advanceTimersByTime(30_000);
+		expect(sub.tick).toBe(initialTick + 2);
+
+		sub.unsubscribe();
+	});
+
+	it("should stop timer when all subscribers unsubscribe", () => {
+		const clearIntervalSpy = vi.spyOn(globalThis, "clearInterval");
+
+		const sub1 = subscribe();
+		const sub2 = subscribe();
+
+		// 1人目が解除しても、まだ2人目がいるので止まらない
+		sub1.unsubscribe();
+		expect(clearIntervalSpy).not.toHaveBeenCalled();
+
+		// 2人目が解除 → subscriber 0 → タイマー停止
+		sub2.unsubscribe();
+		expect(clearIntervalSpy).toHaveBeenCalled();
+
+		clearIntervalSpy.mockRestore();
+	});
+
+	it("should share the same tick across multiple subscribers", () => {
+		const sub1 = subscribe();
+		const sub2 = subscribe();
+
+		vi.advanceTimersByTime(30_000);
+		expect(sub1.tick).toBe(sub2.tick);
+
+		sub1.unsubscribe();
+		sub2.unsubscribe();
+	});
+
+	it("should restart timer after all unsubscribe and new subscribe", () => {
+		const sub1 = subscribe();
+		const initialTick = sub1.tick;
+		vi.advanceTimersByTime(30_000);
+		expect(sub1.tick).toBe(initialTick + 1);
+		sub1.unsubscribe();
+
+		// 再 subscribe → tick はリセットされないがタイマーは再開される
+		const sub2 = subscribe();
+		const tickAfterResubscribe = sub2.tick;
+		vi.advanceTimersByTime(30_000);
+		// tick は前回の続きからインクリメントされる
+		expect(sub2.tick).toBe(tickAfterResubscribe + 1);
+
+		sub2.unsubscribe();
+	});
+});

--- a/src/test/sidepanel/components/RelativeTime.test.ts
+++ b/src/test/sidepanel/components/RelativeTime.test.ts
@@ -1,0 +1,186 @@
+import { flushSync, mount, unmount } from "svelte";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import RelativeTime from "../../../sidepanel/components/RelativeTime.svelte";
+
+describe("RelativeTime", () => {
+	let component: ReturnType<typeof mount> | undefined;
+
+	beforeEach(() => {
+		vi.useFakeTimers();
+		// 2026-03-23T12:00:00Z を現在時刻として固定
+		vi.setSystemTime(new Date("2026-03-23T12:00:00Z"));
+	});
+
+	afterEach(() => {
+		if (component) {
+			unmount(component);
+		}
+		component = undefined;
+		document.body.innerHTML = "";
+		vi.useRealTimers();
+	});
+
+	it("should render formatRelativeTime result on initial mount", () => {
+		// 5分前の日付を渡す → "5m ago" と表示されるはず
+		component = mount(RelativeTime, {
+			target: document.body,
+			props: { dateStr: "2026-03-23T11:55:00Z" },
+		});
+		const span = document.querySelector("span");
+		expect(span).not.toBeNull();
+		expect(span?.textContent).toBe("5m ago");
+	});
+
+	it("should render 'just now' for a date 10 seconds ago", () => {
+		component = mount(RelativeTime, {
+			target: document.body,
+			props: { dateStr: "2026-03-23T11:59:50Z" },
+		});
+		const span = document.querySelector("span");
+		expect(span).not.toBeNull();
+		expect(span?.textContent).toBe("just now");
+	});
+
+	it("should render 'just now' for a future date (5 minutes ahead)", () => {
+		component = mount(RelativeTime, {
+			target: document.body,
+			props: { dateStr: "2026-03-23T12:05:00Z" },
+		});
+		const span = document.querySelector("span");
+		expect(span).not.toBeNull();
+		expect(span?.textContent).toBe("just now");
+	});
+
+	it("should render 'Xd ago' for a date 3 days ago", () => {
+		component = mount(RelativeTime, {
+			target: document.body,
+			props: { dateStr: "2026-03-20T12:00:00Z" },
+		});
+		const span = document.querySelector("span");
+		expect(span).not.toBeNull();
+		expect(span?.textContent).toBe("3d ago");
+	});
+
+	it("should update display after 30 seconds elapse", () => {
+		// 59分30秒前 → 初回は "59m ago"、30秒後に60分経過で "1h ago" になるはず
+		component = mount(RelativeTime, {
+			target: document.body,
+			props: { dateStr: "2026-03-23T11:00:30Z" },
+		});
+		const span = document.querySelector("span");
+		expect(span?.textContent).toBe("59m ago");
+
+		// 30秒進める → 60分経過 → "1h ago"
+		vi.advanceTimersByTime(30_000);
+		flushSync();
+		expect(span?.textContent).toBe("1h ago");
+	});
+
+	it("should not update DOM before 30 seconds but should update at 30 seconds", () => {
+		// 59秒前 → "just now" のはず。29秒後(=88秒前)もまだ "1m ago" にならない
+		// → 30秒後(=89秒前)で "1m ago" に変化
+		component = mount(RelativeTime, {
+			target: document.body,
+			props: { dateStr: "2026-03-23T11:59:01Z" },
+		});
+		const span = document.querySelector("span");
+		expect(span?.textContent).toBe("just now");
+
+		// 29秒では interval がまだ発火していないので変化なし
+		vi.advanceTimersByTime(29_000);
+		flushSync();
+		expect(span?.textContent).toBe("just now");
+
+		// さらに1秒(計30秒)で interval 発火 → 89秒経過 = "1m ago"
+		vi.advanceTimersByTime(1_000);
+		flushSync();
+		expect(span?.textContent).toBe("1m ago");
+	});
+
+	it("should progress through multiple interval cycles: just now → 1m → 1m → 2m", () => {
+		// 20秒前 → "just now"
+		component = mount(RelativeTime, {
+			target: document.body,
+			props: { dateStr: "2026-03-23T11:59:40Z" },
+		});
+		const span = document.querySelector("span");
+		expect(span?.textContent).toBe("just now");
+
+		// 30秒後 → 50秒経過 → "just now" のまま (まだ1分未満)
+		vi.advanceTimersByTime(30_000);
+		flushSync();
+		expect(span?.textContent).toBe("just now");
+
+		// さらに30秒後 → 80秒経過 → "1m ago"
+		vi.advanceTimersByTime(30_000);
+		flushSync();
+		expect(span?.textContent).toBe("1m ago");
+
+		// さらに30秒後 → 110秒経過 → まだ2分未満なので "1m ago"
+		vi.advanceTimersByTime(30_000);
+		flushSync();
+		expect(span?.textContent).toBe("1m ago");
+
+		// さらに30秒後 → 140秒経過 → 2分超えたので "2m ago"
+		vi.advanceTimersByTime(30_000);
+		flushSync();
+		expect(span?.textContent).toBe("2m ago");
+	});
+
+	it("should render correct value for different dateStr props", () => {
+		// 最初は5分前
+		component = mount(RelativeTime, {
+			target: document.body,
+			props: { dateStr: "2026-03-23T11:55:00Z" },
+		});
+		const span = document.querySelector("span");
+		expect(span?.textContent).toBe("5m ago");
+
+		// アンマウントして新しい props で再マウント
+		unmount(component);
+		document.body.innerHTML = "";
+
+		// 2時間前の日付で再マウント
+		component = mount(RelativeTime, {
+			target: document.body,
+			props: { dateStr: "2026-03-23T10:00:00Z" },
+		});
+		const newSpan = document.querySelector("span");
+		expect(newSpan?.textContent).toBe("2h ago");
+	});
+
+	it("should stop shared timer when last subscriber unmounts", () => {
+		const clearIntervalSpy = vi.spyOn(globalThis, "clearInterval");
+
+		component = mount(RelativeTime, {
+			target: document.body,
+			props: { dateStr: "2026-03-23T11:55:00Z" },
+		});
+
+		unmount(component);
+		component = undefined;
+
+		expect(clearIntervalSpy).toHaveBeenCalled();
+		clearIntervalSpy.mockRestore();
+	});
+
+	it("should safely render a dash for invalid date strings", () => {
+		component = mount(RelativeTime, {
+			target: document.body,
+			props: { dateStr: "not-a-date" },
+		});
+		const span = document.querySelector("span");
+		expect(span).not.toBeNull();
+		expect(span?.textContent).toBe("\u2014");
+	});
+
+	it("should safely render a dash for empty string", () => {
+		component = mount(RelativeTime, {
+			target: document.body,
+			props: { dateStr: "" },
+		});
+		const span = document.querySelector("span");
+		expect(span).not.toBeNull();
+		expect(span?.textContent).toBe("\u2014");
+	});
+});


### PR DESCRIPTION
## 概要
PR一覧の更新日時表示が「just now」のまま固定されるバグを修正。共有タイマーストアで30秒ごとに tick を更新し、`$derived` で `formatRelativeTime` を再計算する `RelativeTime` コンポーネントを追加した。

## 変更内容
- `src/shared/stores/relative-time-tick.svelte.ts`: 参照カウント付き共有タイマーストア（モジュールレベル単一 `setInterval`）を新規作成
- `src/sidepanel/components/RelativeTime.svelte`: 共有タイマーの tick を `$derived.by` で監視し、30秒ごとに相対時刻を再計算するコンポーネントを新規作成
- `src/sidepanel/components/PrItem.svelte`: `formatRelativeTime()` 直接呼び出しを `<RelativeTime>` コンポーネントに置換
- `src/sidepanel/components/MainScreen.svelte`: 同上（ヘッダーの最終更新日時）
- `src/test/shared/stores/relative-time-tick.svelte.test.ts`: 共有タイマーストアのテスト（subscribe/unsubscribe/参照カウント/タイマー停止）
- `src/test/sidepanel/components/RelativeTime.test.ts`: RelativeTime コンポーネントの包括的テスト（11ケース: 初期表示、interval 更新、複数サイクル、境界値、cleanup、不正入力）

## 関連 Issue
- closes #155

## テスト
- [x] TypeScript 型チェック通過 (`pnpm check`)
- [x] フロントエンドテスト通過 (`pnpm test`) — 438 tests passed
- [x] Rust lint 通過 (`cargo clippy --all-targets`)
- [x] Rust テスト通過 (`cargo test`) — 36 tests passed
- [x] `/verify` で検証ループ PASS

## レビュー観点
- **共有タイマーストアの設計**: 参照カウント方式でタイマーのライフサイクルを管理。subscriber が 0 になったらタイマー停止。`unsubscribe()` の多重呼び出し防御は入れていない（Svelte の `$effect.pre` cleanup は1回のみ呼ばれるため実害なし）
- **`$derived.by` + `void timer.tick` パターン**: tick を依存として宣言し、`formatRelativeTime(dateStr)` を再計算。`dateStr` 変更にもリアクティブに追従する
- **`$effect.pre` vs `$effect`**: `$effect.pre` は同期的に初期化されるため、即座の `unmount` でも確実に cleanup が実行される。`$effect` はマウント完了まで遅延されるため不適