### PR TITLE
chore: ビルドコマンドを整理しGITHUB_CLIENT_IDをハードコード

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
 	"version": "0.0.1",
 	"scripts": {
 		"dev": "vite",
-		"build": "vite build",
+		"build": "GITHUB_CLIENT_ID=Ov23liCgU4UCzg03tnCK vite build",
+		"build:wasm": "cd rust-core/crates/adapter-wasm && wasm-pack build --target web",
+		"build:all": "pnpm build:wasm && pnpm build",
 		"check": "svelte-check --tsconfig ./tsconfig.json",
 		"test": "vitest run",
 		"test:watch": "vitest",


### PR DESCRIPTION
## 概要
WASM + フロントエンドの一括ビルドコマンドを追加し、GITHUB_CLIENT_ID を build スクリプトに埋め込み。

## 変更内容
- `package.json`: `build:wasm` / `build:all` スクリプトを追加
- `package.json`: `build` スクリプトに `GITHUB_CLIENT_ID` をハードコード（Device Flow では公開情報）

## 関連 Issue
なし（開発体験の改善）

## テスト
- [x] `pnpm build:all` で WASM + フロントエンドが一括ビルドできること
- [ ] `pnpm build:wasm` で WASM 単体ビルドできること
- [ ] `pnpm build` で環境変数指定なしにビルドできること
- [ ] `pnpm test` 全テスト通過
- [ ] Rust テスト通過

## レビュー観点
- `GITHUB_CLIENT_ID` は OAuth Device Flow の公開値であり、セキュリティ上問題なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)