### PR TITLE
chore: スキルリファレンスの gh api パス形式を統一

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -9,9 +9,7 @@
 			"Bash(gh label:*)",
 			"Bash(gh auth status:*)",
 			"Bash(gh api graphql:*)",
-			"Bash(gh api repos/:*)",
 			"Bash(gh api /repos/:*)",
-			"Bash(gh api -X DELETE repos/:*)",
 			"Bash(gh api -X DELETE /repos/:*)"
 		],
 		"deny": [

--- a/.claude/skills/issue/reference/sub-issues.md
+++ b/.claude/skills/issue/reference/sub-issues.md
@@ -11,7 +11,7 @@
 CHILD_ID=$(gh api /repos/{owner}/{repo}/issues/$CHILD_NUMBER --jq .id)
 
 # 親 issue にサブ issue として追加
-gh api repos/{owner}/{repo}/issues/$PARENT_NUMBER/sub_issues \
+gh api /repos/{owner}/{repo}/issues/$PARENT_NUMBER/sub_issues \
   -f sub_issue_id="$CHILD_ID"
 ```
 
@@ -47,7 +47,7 @@ gh api graphql \
 ## Sub-issue 解除
 
 ```bash
-echo '{"sub_issue_id": 子の数値id}' | gh api -X DELETE repos/OWNER/REPO/issues/親の番号/sub_issue --input -
+echo '{"sub_issue_id": 子の数値id}' | gh api -X DELETE /repos/OWNER/REPO/issues/親の番号/sub_issue --input -
 ```
 
 ## 参照


### PR DESCRIPTION
## 概要
`.claude/skills/issue/reference/sub-issues.md` 内で混在していた `gh api repos/` (先頭スラッシュなし) と `gh api /repos/` (先頭スラッシュあり) のパス形式を `/repos/` に統一し、不要になった settings.json の許可パターンを削除。

## 変更内容
- `.claude/skills/issue/reference/sub-issues.md`: 2箇所の `gh api repos/` → `gh api /repos/` に修正 (サブ issue 追加コマンド、サブ issue 解除コマンド)
- `.claude/settings.json`: `Bash(gh api repos/:*)` と `Bash(gh api -X DELETE repos/:*)` の2パターンを削除

## 関連 Issue
- closes #71

## テスト
- [x] TypeScript 型チェック通過 (`pnpm check`)
- [x] フロントエンドテスト通過 (`pnpm test`)
- [x] Rust lint 通過 (`cargo clippy --all-targets`)
- [x] Rust テスト通過 (`cargo test`)
- [x] `/verify` で検証ループ PASS

## レビュー観点
- `sub-issues.md` 内のコマンド例が正しい `gh api` パス形式 (`/repos/` 先頭スラッシュあり) になっているか
- `settings.json` の allow リストから削除したパターンが本当に不要か（残った `/repos/` パターンでカバーされているか）