### PR TITLE
chore: import.meta.env.DEV ガードの本番ビルド検証を CI に追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,3 +105,9 @@ jobs:
 
       - name: Run tests
         run: pnpm test
+
+      - name: Production build
+        run: pnpm build
+
+      - name: Verify no DEV logs in production build
+        run: bash scripts/verify-no-dev-logs.sh

--- a/scripts/verify-no-dev-logs.sh
+++ b/scripts/verify-no-dev-logs.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ ! -d "dist" ]; then
+  echo "ERROR: dist/ directory does not exist"
+  exit 1
+fi
+
+violation_found=0
+
+# DEV ログプレフィックスのパターンを構築
+dev_log_prefixes=(
+  '\[identity\.adapter\]'
+  '\[storage\]'
+  '\[message-handler\]'
+  '\[bootstrap\]'
+  '\[MainScreen\]'
+  '\[auto-refresh\]'
+  '\[auth\.usecase\]'
+  '\[pr\.usecase\]'
+)
+
+pattern=""
+for prefix in "${dev_log_prefixes[@]}"; do
+  if [ -z "$pattern" ]; then
+    pattern="$prefix"
+  else
+    pattern="${pattern}|${prefix}"
+  fi
+done
+
+# 1回の find ループで両方のチェックを実行
+while IFS= read -r -d '' file; do
+  # import.meta.env.DEV の残存チェック
+  set +e
+  grep -n 'import\.meta\.env\.DEV' "$file"; rc=$?
+  set -e
+  if [ "$rc" -eq 0 ]; then
+    echo "VIOLATION: import.meta.env.DEV found in ${file}"
+    violation_found=1
+  elif [ "$rc" -ge 2 ]; then
+    echo "ERROR: grep failed on ${file}"
+    exit 1
+  fi
+
+  # DEV ログプレフィックスの残存チェック
+  set +e
+  grep -nE "$pattern" "$file"; rc=$?
+  set -e
+  if [ "$rc" -eq 0 ]; then
+    echo "VIOLATION: DEV log prefix found in ${file}"
+    violation_found=1
+  elif [ "$rc" -ge 2 ]; then
+    echo "ERROR: grep failed on ${file}"
+    exit 1
+  fi
+done < <(find dist -name '*.js' -print0)
+
+if [ "$violation_found" -eq 1 ]; then
+  echo "FAILED: DEV logs detected in production build"
+  exit 1
+fi
+
+echo "PASSED: No DEV logs found in production build"
+exit 0

--- a/scripts/verify-no-dev-logs.test.sh
+++ b/scripts/verify-no-dev-logs.test.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+TARGET_SCRIPT="${SCRIPT_DIR}/verify-no-dev-logs.sh"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+TOTAL=0
+
+report() {
+  local name="$1"
+  local expected="$2"
+  local actual="$3"
+  TOTAL=$((TOTAL + 1))
+  if [ "$expected" = "$actual" ]; then
+    echo "PASS: ${name}"
+    PASS_COUNT=$((PASS_COUNT + 1))
+  else
+    echo "FAIL: ${name} (expected exit ${expected}, got exit ${actual})"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  fi
+}
+
+# ヘルパー: DEV ログプレフィックスが検出されるべきケースを生成して検証する
+# $1: テスト名
+# $2: JS ファイル名 (dist/ 配下)
+# $3: JS ファイルの中身
+run_test_dev_log_detected() {
+  local test_name="$1"
+  local js_filename="$2"
+  local js_content="$3"
+
+  local tmpdir
+  tmpdir="$(mktemp -d)"
+  trap "rm -rf '${tmpdir}'" RETURN
+
+  mkdir -p "${tmpdir}/dist"
+  echo "${js_content}" > "${tmpdir}/dist/${js_filename}"
+
+  local exit_code=0
+  (cd "${tmpdir}" && bash "${TARGET_SCRIPT}") >/dev/null 2>&1 || exit_code=$?
+  report "${test_name}" "1" "${exit_code}"
+}
+
+# --- Test 1: Clean dist with no DEV logs -> exit 0 ---
+run_test_clean() {
+  local tmpdir
+  tmpdir="$(mktemp -d)"
+  trap "rm -rf '${tmpdir}'" RETURN
+
+  mkdir -p "${tmpdir}/dist"
+  cat > "${tmpdir}/dist/app.js" <<'JSEOF'
+console.log("production code");
+function hello() { return 42; }
+JSEOF
+
+  local exit_code=0
+  (cd "${tmpdir}" && bash "${TARGET_SCRIPT}") >/dev/null 2>&1 || exit_code=$?
+  report "Clean dist (no DEV logs) -> exit 0" "0" "${exit_code}"
+}
+
+# --- Test 2: dist contains import.meta.env.DEV -> exit 1 ---
+run_test_import_meta_env_dev() {
+  local tmpdir
+  tmpdir="$(mktemp -d)"
+  trap "rm -rf '${tmpdir}'" RETURN
+
+  mkdir -p "${tmpdir}/dist"
+  cat > "${tmpdir}/dist/app.js" <<'JSEOF'
+if (import.meta.env.DEV) { console.log("debug"); }
+JSEOF
+
+  local exit_code=0
+  (cd "${tmpdir}" && bash "${TARGET_SCRIPT}") >/dev/null 2>&1 || exit_code=$?
+  report "import.meta.env.DEV残存 -> exit 1" "1" "${exit_code}"
+}
+
+# --- Test 3: DEV log prefixes with console.log (代表2パターン) ---
+run_test_dev_log_prefix_identity_adapter() {
+  run_test_dev_log_detected \
+    "console.log + DEVログプレフィックス ([identity.adapter]) -> exit 1" \
+    "app.js" \
+    'console.log("[identity.adapter] initialized");'
+}
+
+run_test_dev_log_prefix_bootstrap() {
+  run_test_dev_log_detected \
+    "console.log + DEVログプレフィックス ([bootstrap]) -> exit 1" \
+    "main.js" \
+    'console.log("[bootstrap] starting app");'
+}
+
+# --- Test 4: console.error with DEV log prefix -> exit 1 ---
+run_test_dev_log_console_error() {
+  run_test_dev_log_detected \
+    "console.error + DEVログプレフィックス ([identity.adapter]) -> exit 1" \
+    "app.js" \
+    'console.error("[identity.adapter] failed to load token");'
+}
+
+# --- Test 5: console.warn with DEV log prefix -> exit 1 ---
+run_test_dev_log_console_warn() {
+  run_test_dev_log_detected \
+    "console.warn + DEVログプレフィックス ([bootstrap]) -> exit 1" \
+    "main.js" \
+    'console.warn("[bootstrap] fallback to default config");'
+}
+
+# --- Test 6: 複数ファイルで1つだけ違反 (サブディレクトリ含む) -> exit 1 ---
+run_test_multi_file_one_violation() {
+  local tmpdir
+  tmpdir="$(mktemp -d)"
+  trap "rm -rf '${tmpdir}'" RETURN
+
+  mkdir -p "${tmpdir}/dist/assets"
+  # クリーンなファイル
+  cat > "${tmpdir}/dist/app.js" <<'JSEOF'
+console.log("production ready");
+function init() { return true; }
+JSEOF
+  # サブディレクトリ内の違反ファイル
+  cat > "${tmpdir}/dist/assets/chunk-a1b2c3.js" <<'JSEOF'
+console.log("[storage] saving data");
+JSEOF
+
+  local exit_code=0
+  (cd "${tmpdir}" && bash "${TARGET_SCRIPT}") >/dev/null 2>&1 || exit_code=$?
+  report "複数ファイル: サブディレクトリの1ファイルだけ違反 -> exit 1" "1" "${exit_code}"
+}
+
+# --- Test 7: import.meta.env.DEV と DEV ログプレフィックスが同時に存在 -> exit 1 ---
+run_test_both_violations() {
+  local tmpdir
+  tmpdir="$(mktemp -d)"
+  trap "rm -rf '${tmpdir}'" RETURN
+
+  mkdir -p "${tmpdir}/dist"
+  cat > "${tmpdir}/dist/app.js" <<'JSEOF'
+if (import.meta.env.DEV) { console.warn("[auto-refresh] polling"); }
+console.error("[identity.adapter] token expired");
+JSEOF
+
+  local exit_code=0
+  (cd "${tmpdir}" && bash "${TARGET_SCRIPT}") >/dev/null 2>&1 || exit_code=$?
+  report "import.meta.env.DEV + DEVログプレフィックス両方存在 -> exit 1" "1" "${exit_code}"
+}
+
+# --- Test 8: dist directory does not exist -> exit 1 ---
+run_test_no_dist_dir() {
+  local tmpdir
+  tmpdir="$(mktemp -d)"
+  trap "rm -rf '${tmpdir}'" RETURN
+
+  # dist/ を作らない
+  local exit_code=0
+  (cd "${tmpdir}" && bash "${TARGET_SCRIPT}") >/dev/null 2>&1 || exit_code=$?
+  report "dist/が存在しない -> exit 1" "1" "${exit_code}"
+}
+
+# --- Run all tests ---
+echo "=== verify-no-dev-logs.sh テスト ==="
+echo ""
+
+run_test_clean
+run_test_import_meta_env_dev
+run_test_dev_log_prefix_identity_adapter
+run_test_dev_log_prefix_bootstrap
+run_test_dev_log_console_error
+run_test_dev_log_console_warn
+run_test_multi_file_one_violation
+run_test_both_violations
+run_test_no_dist_dir
+
+echo ""
+echo "=== 結果: ${PASS_COUNT}/${TOTAL} PASS, ${FAIL_COUNT}/${TOTAL} FAIL ==="
+
+if [ "${FAIL_COUNT}" -gt 0 ]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## 概要

CI パイプラインに本番ビルド成果物の `import.meta.env.DEV` ガード検証ステップを追加。Vite の設定ミスで DEV ブロックが本番ビルドに残留するリスクを CI で防止する。

## 変更内容

- `scripts/verify-no-dev-logs.sh`: 本番ビルド成果物 (`dist/`) 内の JS ファイルに `import.meta.env.DEV` や DEV ログプレフィックス (`[identity.adapter]`, `[storage]`, `[bootstrap]` 等 8 種) が残存していないことを検証するスクリプト。grep exit code 2 (ファイル読み取りエラー) も検出して異常終了する
- `scripts/verify-no-dev-logs.test.sh`: 正常系・異常系 9 ケースのテスト (console.log/error/warn パターン、複数ファイル、サブディレクトリ、複合違反等)
- `.github/workflows/ci.yml`: `typescript` ジョブに `Production build` (`pnpm build`) と `Verify no DEV logs in production build` ステップを追加

## 関連 Issue

- closes #104

## テスト

- [ ] TypeScript 型チェック通過 (`pnpm check`) — 既存エラー (`src/wasm/pr-processor.ts`) あり、今回の変更と無関係
- [x] フロントエンドテスト通過 (`pnpm test`)
- [x] Rust lint 通過 (`cargo clippy --all-targets`)
- [x] Rust テスト通過 (`cargo test`)
- [x] `/verify` で検証ループ PASS

## レビュー観点

- `scripts/verify-no-dev-logs.sh` の grep パターンが DEV ログプレフィックス全種をカバーしているか
- CI ステップの配置順 (`pnpm build` → `verify-no-dev-logs.sh`) が適切か
- `grep` の exit code ハンドリング (`set +e` / `set -e` の切り替え) が正しいか