### PR TITLE
feat: GraphQL mutation ホワイトリスト制限を pre-command hook に追加

### DIFF
--- a/.claude/hooks/pre-command-secret-check.sh
+++ b/.claude/hooks/pre-command-secret-check.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
-# PreToolUse hook: Bash コマンド実行前にシークレット漏洩をチェック
-# シークレットがコマンドに含まれていたらブロックする
+# PreToolUse hook: Bash コマンド実行前にセキュリティチェックを行う
+# 1. シークレット漏洩の検出・ブロック
+# 2. GraphQL mutation のホワイトリスト制限 (#72)
 
 set -euo pipefail
 
@@ -18,47 +19,96 @@ fi
 # --- 高速パス: 1回の grep -E で全パターン一括チェック ---
 FAST_PATTERN="client_secret|access_token|GITHUB_TOKEN|GITHUB_OAUTH|GH_TOKEN|GH_CLIENT_SECRET|OAUTH_TOKEN|ghp_|gho_|ghs_|github_pat_|export\s+-p|printenv|compgen\s+-v|declare\s+-(x|p)|set\s*\|\s*grep|/proc/.*environ|authorization.*bearer"
 
-if ! printf '%s' "$COMMAND" | grep -qiE "$FAST_PATTERN"; then
-  exit 0  # 正常系: 高速パスで即通過
+HAS_SECRET_PATTERN=false
+if printf '%s' "$COMMAND" | grep -qiE "$FAST_PATTERN"; then
+  HAS_SECRET_PATTERN=true
 fi
 
-# --- ブロック時: 個別パターンで特定 ---
-PATTERNS=(
-  # シークレット文字列
-  "client_secret"
-  "access_token"
-  "GITHUB_TOKEN"
-  "GITHUB_OAUTH"
-  "GH_TOKEN"          # GITHUB_TOKEN とは別の環境変数
-  "GH_CLIENT_SECRET"
-  "OAUTH_TOKEN"
-  "ghp_"              # GitHub PAT prefix
-  "gho_"              # GitHub OAuth token prefix
-  "ghs_"              # GitHub App installation token prefix
-  "github_pat_"       # fine-grained PAT prefix
-  # 環境変数ダンプ系コマンド (迂回防止)
-  "export -p"
-  "printenv"
-)
+# GraphQL mutation チェックが必要か判定
+HAS_GQL_MUTATION=false
+if printf '%s' "$COMMAND" | grep -qE 'gh\s+api\s+graphql'; then
+  if printf '%s' "$COMMAND" | grep -qiE 'mutation(\s+\w+)?\s*\{'; then
+    HAS_GQL_MUTATION=true
+  fi
+fi
 
-for pattern in "${PATTERNS[@]}"; do
-  if printf '%s' "$COMMAND" | grep -qi "$pattern"; then
-    echo "BLOCK: シークレット '$pattern' がコマンドに含まれています。環境変数または chrome.storage を使ってください。" >&2
+# どちらにも該当しなければ即通過
+if [ "$HAS_SECRET_PATTERN" = false ] && [ "$HAS_GQL_MUTATION" = false ]; then
+  exit 0
+fi
+
+# --- シークレットパターンチェック ---
+# NOTE: シークレットチェックが先行し、該当すれば exit 2 で即終了する。
+# GraphQL mutation チェックはシークレットを含まないコマンドにのみ到達する。
+if [ "$HAS_SECRET_PATTERN" = true ]; then
+  # 個別パターンで特定
+  PATTERNS=(
+    # シークレット文字列
+    "client_secret"
+    "access_token"
+    "GITHUB_TOKEN"
+    "GITHUB_OAUTH"
+    "GH_TOKEN"          # GITHUB_TOKEN とは別の環境変数
+    "GH_CLIENT_SECRET"
+    "OAUTH_TOKEN"
+    "ghp_"              # GitHub PAT prefix
+    "gho_"              # GitHub OAuth token prefix
+    "ghs_"              # GitHub App installation token prefix
+    "github_pat_"       # fine-grained PAT prefix
+    # 環境変数ダンプ系コマンド (迂回防止)
+    "export -p"
+    "printenv"
+  )
+
+  for pattern in "${PATTERNS[@]}"; do
+    if printf '%s' "$COMMAND" | grep -qi "$pattern"; then
+      echo "BLOCK: シークレット '$pattern' がコマンドに含まれています。環境変数または chrome.storage を使ってください。" >&2
+      exit 2
+    fi
+  done
+
+  # ERE 専用パターン (BRE では表現できない / スペース迂回対策が必要なもの)
+  ERE_PATTERNS=(
+    "/proc/.*environ"
+    "authorization.*bearer"
+    "set\s*\|\s*grep"
+    "declare\s+-(x|p)"
+    "compgen\s+-v"
+  )
+  for pattern in "${ERE_PATTERNS[@]}"; do
+    if printf '%s' "$COMMAND" | grep -qiE "$pattern"; then
+      echo "BLOCK: シークレットパターン '$pattern' がコマンドに含まれています。環境変数または chrome.storage を使ってください。" >&2
+      exit 2
+    fi
+  done
+fi
+
+# --- GraphQL mutation ホワイトリスト (#72) ---
+if [ "$HAS_GQL_MUTATION" = true ]; then
+  ALLOWED_MUTATIONS=(
+    "addProjectV2ItemById"
+    "updateProjectV2ItemFieldValue"
+    "addBlockedBy"
+    "removeBlockedBy"
+    "addSubIssue"
+  )
+
+  # mutation 名を抽出: mutation (OperationName)? { の後の最初の識別子
+  # Named mutation (例: mutation MyOp { addX(...) }) にも対応
+  MUTATION_NAME=$(printf '%s' "$COMMAND" | grep -oiP 'mutation(\s+\w+)?\s*\{\s*\K[a-zA-Z]\w*' | head -1 || true)
+
+  if [ -z "$MUTATION_NAME" ]; then
+    echo "BLOCK: GraphQL mutation の名前を特定できません。許可された mutation: ${ALLOWED_MUTATIONS[*]}" >&2
     exit 2
   fi
-done
 
-# ERE 専用パターン (BRE では表現できない / スペース迂回対策が必要なもの)
-ERE_PATTERNS=(
-  "/proc/.*environ"
-  "authorization.*bearer"
-  "set\s*\|\s*grep"
-  "declare\s+-(x|p)"
-  "compgen\s+-v"
-)
-for pattern in "${ERE_PATTERNS[@]}"; do
-  if printf '%s' "$COMMAND" | grep -qiE "$pattern"; then
-    echo "BLOCK: シークレットパターン '$pattern' がコマンドに含まれています。環境変数または chrome.storage を使ってください。" >&2
-    exit 2
-  fi
-done
+  # ホワイトリストチェック
+  for allowed in "${ALLOWED_MUTATIONS[@]}"; do
+    if [ "$MUTATION_NAME" = "$allowed" ]; then
+      exit 0
+    fi
+  done
+
+  echo "BLOCK: GraphQL mutation '$MUTATION_NAME' は許可されていません。許可された mutation: ${ALLOWED_MUTATIONS[*]}" >&2
+  exit 2
+fi

--- a/.claude/hooks/tests/test-pre-command-secret-check.sh
+++ b/.claude/hooks/tests/test-pre-command-secret-check.sh
@@ -195,6 +195,70 @@ assert_allowed "29: set -euo pipefail は許可 (set | grep ではない)" \
 assert_allowed "30: export 文字列を含むが環境変数ダンプではない" \
   'echo "export data to file"'
 
+# --- Issue #72: GraphQL mutation ホワイトリスト ---
+
+echo ""
+echo "=== GraphQL mutation ホワイトリスト (#72) ==="
+
+# ブロックすべきケース: 許可外 mutation
+assert_blocked "31: 許可外 mutation deleteProjectV2Item をブロック" \
+  'gh api graphql -f query='"'"'mutation { deleteProjectV2Item(input: { itemId: "xxx" }) { deletedItemId } }'"'"''
+
+assert_blocked "32: 許可外 mutation createIssue をブロック" \
+  'gh api graphql -f query='"'"'mutation { createIssue(input: { repositoryId: "xxx", title: "test" }) { issue { id } } }'"'"''
+
+assert_blocked "33: 許可外 mutation deleteIssue をブロック" \
+  'gh api graphql -f query='"'"'mutation { deleteIssue(input: { issueId: "xxx" }) { repository { id } } }'"'"''
+
+assert_blocked "34: 許可外 mutation transferIssue をブロック" \
+  'gh api graphql -f query='"'"'mutation { transferIssue(input: { issueId: "xxx", repositoryId: "yyy" }) { issue { id } } }'"'"''
+
+# NOTE: 以下のテストは現時点 (プロダクションコード未実装) では素通りで PASS する。
+# mutation ブロックロジック実装後も、ホワイトリスト内なので引き続き PASS する想定。
+assert_allowed "35: ホワイトリスト mutation addProjectV2ItemById を許可" \
+  'gh api graphql -f query='"'"'mutation { addProjectV2ItemById(input: { projectId: "PVT_xxx", contentId: "I_xxx" }) { item { id } } }'"'"''
+
+assert_allowed "36: ホワイトリスト mutation updateProjectV2ItemFieldValue を許可" \
+  'gh api graphql -f query='"'"'mutation { updateProjectV2ItemFieldValue(input: { projectId: "PVT_xxx", itemId: "PVTI_xxx", fieldId: "PVTSSF_xxx", value: { singleSelectOptionId: "xxx" } }) { projectV2Item { id } } }'"'"''
+
+assert_allowed "37: ホワイトリスト mutation addBlockedBy を許可" \
+  'gh api graphql -f query='"'"'mutation { addBlockedBy(input: { blockedByIssueId: "xxx", issueId: "yyy" }) { blockedByIssue { id } } }'"'"''
+
+assert_allowed "38: ホワイトリスト mutation removeBlockedBy を許可" \
+  'gh api graphql -f query='"'"'mutation { removeBlockedBy(input: { blockedByIssueId: "xxx", issueId: "yyy" }) { unblockedIssue { id } } }'"'"''
+
+assert_allowed "39: ホワイトリスト mutation addSubIssue を許可" \
+  'gh api graphql -f query='"'"'mutation { addSubIssue(input: { issueId: "xxx", subIssueId: "yyy" }) { issue { id } } }'"'"''
+
+# 許可すべきケース: mutation ではない / gh api graphql ではない
+assert_allowed "40: GraphQL query (mutation ではない) は許可" \
+  'gh api graphql -f query='"'"'{ repository(owner: "kohchan0913", name: "pr-sideber") { issue(number: 1) { id } } }'"'"''
+
+assert_allowed "41: mutation 文字列を含むが gh api graphql ではないコマンドは許可" \
+  'echo "mutation test string"'
+
+# エッジケース: スペースなし / 大文字小文字
+assert_blocked "42: mutation{スペースなし の許可外 mutation をブロック" \
+  'gh api graphql -f query='"'"'mutation{deleteProjectV2Item(input:{itemId:"xxx"}){deletedItemId}}'"'"''
+
+assert_blocked "43: MUTATION (大文字) の許可外 mutation をブロック" \
+  'gh api graphql -f query='"'"'MUTATION { deleteProjectV2Item(input: { itemId: "xxx" }) { deletedItemId } }'"'"''
+
+assert_allowed "44: mutation{addProjectV2ItemById スペースなしで許可" \
+  'gh api graphql -f query='"'"'mutation{addProjectV2ItemById(input:{projectId:"PVT_xxx",contentId:"I_xxx"}){item{id}}}'"'"''
+
+assert_allowed "45: 明示的 query キーワード付き GraphQL は許可" \
+  'gh api graphql -f query='"'"'query { repository(owner: "x", name: "y") { id } }'"'"''
+
+assert_allowed "46: grep mutation コマンドは許可" \
+  'grep mutation src/some-file.ts'
+
+assert_allowed "47: MUTATION キーワードでもホワイトリスト mutation は許可" \
+  'gh api graphql -f query='"'"'MUTATION { addProjectV2ItemById(input: { projectId: "PVT_xxx", contentId: "I_xxx" }) { item { id } } }'"'"''
+
+assert_blocked "48: Named mutation はブロック (mutation 名と間違えるリスク)" \
+  'gh api graphql -f query='"'"'mutation MyOperation { deleteProjectV2Item(input: { itemId: "xxx" }) { deletedItemId } }'"'"''
+
 # --- 結果サマリ ---
 
 echo ""


### PR DESCRIPTION
## 概要

pre-command-secret-check.sh hook に GraphQL mutation のホワイトリスト制限を追加。許可外の mutation (`deleteProjectV2Item`, `createIssue` 等) を自動ブロックし、Issue/PR の意図しない破壊操作を防止する。

## 変更内容

- `.claude/hooks/pre-command-secret-check.sh`
  - 高速パスを2段階判定 (`HAS_SECRET_PATTERN` / `HAS_GQL_MUTATION`) に構造変更
  - GraphQL コマンドで mutation 名を PCRE で抽出
  - 5つの許可 mutation のみ通過、それ以外は exit 2 でブロック
  - Named mutation (`mutation MyOp { ... }`) にも対応
  - スペース複数パターンにも対応
  - `|| true` で grep マッチなし時のスクリプト即死を防止
  - ファイル冒頭コメントを両責務 (シークレット + mutation) に更新
- `.claude/hooks/tests/test-pre-command-secret-check.sh`
  - GraphQL mutation テスト18件追加 (合計52件、全 PASS)

## 関連 Issue

closes #72

## テスト

- [x] 全52テスト PASS (既存30件の回帰なし)
- [x] 許可外 mutation のブロック確認 (deleteProjectV2Item, createIssue 等)
- [x] ホワイトリスト mutation の許可確認 (addProjectV2ItemById 等)
- [x] Named mutation / 大文字 MUTATION / スペースなしバリアント対応確認
- [ ] WASM ビルド (変更なし)

## レビュー観点

- 高速パスの構造変更 (2変数分岐) が既存シークレットチェックに悪影響を与えていないか
- PCRE (`grep -oiP`) での mutation 名抽出が想定外の入力で壊れないか
- ホワイトリストの5 mutation が過不足ないか

### /verify 検証結果

- テスト: 52 passed, 0 failed
- セキュリティ: 4観点レビュー実施済み (HIGH 指摘は安全方向のため対応不要と判断)
- diff: hook スクリプトとテストのみ、プロダクションコードへの影響なし

https://claude.ai/code/session_01AymsJM2Jiiimt6Frevyt2S
