### PR TITLE
feat: 自動更新間隔を2分から30秒に短縮する

### DIFF
--- a/src/shared/usecase/auto-refresh.usecase.ts
+++ b/src/shared/usecase/auto-refresh.usecase.ts
@@ -14,7 +14,7 @@ type AutoRefreshDeps = {
 
 export function createAutoRefreshUseCase(deps: AutoRefreshDeps) {
 	const ALARM_NAME = "pr-refresh";
-	const INTERVAL_MINUTES = 2;
+	const INTERVAL_MINUTES = 0.5; // 30秒 (chrome.alarms の最小値)
 
 	let started = false;
 	let unsubscribe: (() => void) | null = null;

--- a/src/test/shared/usecase/auto-refresh.usecase.test.ts
+++ b/src/test/shared/usecase/auto-refresh.usecase.test.ts
@@ -85,11 +85,11 @@ describe("auto-refresh usecase", () => {
 	}
 
 	describe("start", () => {
-		it("should create an alarm named 'pr-refresh' with 2-minute interval", async () => {
+		it("should create an alarm named 'pr-refresh' with 30-second interval", async () => {
 			const useCase = createUseCase();
 			await useCase.start();
 
-			expect(mockAlarm.create).toHaveBeenCalledWith("pr-refresh", 2);
+			expect(mockAlarm.create).toHaveBeenCalledWith("pr-refresh", 0.5);
 		});
 
 		it("should register an onAlarm listener", async () => {


### PR DESCRIPTION
## 概要
PR 一覧の自動更新間隔を2分から30秒に短縮し、PR の状態変化（CI 完了、Approve、新規 PR）をよりリアルタイムに検知できるようにした。

## 変更内容
- `src/shared/usecase/auto-refresh.usecase.ts`: `INTERVAL_MINUTES` を `2` から `0.5` に変更（chrome.alarms の MV3 最小値）。意図を明確にするコメント追加
- `src/test/shared/usecase/auto-refresh.usecase.test.ts`: テスト名とアサーション値を30秒間隔に更新

## 関連 Issue
- closes #178

## テスト
- [x] TypeScript 型チェック通過 (`pnpm check`)
- [x] フロントエンドテスト通過 (`pnpm test`) — 40 files / 489 tests
- [x] Rust lint 通過 (`cargo clippy --all-targets`)
- [x] Rust テスト通過 (`cargo test`) — 30 tests
- [x] `/verify` で検証ループ PASS

## レビュー観点
- `periodInMinutes = 0.5` は chrome.alarms の MV3 最小値（30秒）。Issue で Rate Limit 計算済み（120 req/hr = 5,000 pts/hr の 2.4%）
- レビューで出た関連改善は後続 Issue に分離済み: #184 (排他制御), #185 (storage 差分チェック), #186 (キャッシュ閾値定数化)