### PR TITLE
chore: 不要な .env / .env.example を削除する

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,0 @@
-GITHUB_CLIENT_ID=your_github_client_id


### PR DESCRIPTION
## 概要
ビルドで参照されていない `.env.example` を git から削除する。`GITHUB_CLIENT_ID` は `package.json` の build スクリプトに直接指定されており、`.env` ファイルベースの設定管理は使われていないため、残存する `.env.example` は誤った運用を誘導するリスクがある。

## 変更内容
- `.env.example`: git から削除（内容: `GITHUB_CLIENT_ID=your_github_client_id`）
- `.gitignore`: 変更なし（`.env` 関連エントリは安全策として残置）

## 関連 Issue
- closes #187

## テスト
- [ ] TypeScript 型チェック通過 (`pnpm check`)
- [x] フロントエンドテスト通過 (`pnpm test`)
- [ ] Rust lint 通過 (`cargo clippy --all-targets`)
- [x] Rust テスト通過 (`cargo test`)
- [x] `/verify` で検証ループ PASS

## レビュー観点
- `.env.example` を参照しているコードが他にないことの確認（Grep で確認済み、参照ゼロ）
- `.gitignore` の `.env` 関連エントリが残っていることの確認（安全策として意図的に残置）