### PR TITLE
feat: PR一覧にコンフリクト状態を表示する (#180)

### DIFF
--- a/rust-core/crates/adapter-wasm/src/dto.rs
+++ b/rust-core/crates/adapter-wasm/src/dto.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 use tsify_next::Tsify;
 
 use domain::entity::PullRequest;
-use domain::status::{ApprovalStatus, CiStatus};
+use domain::status::{ApprovalStatus, CiStatus, MergeableStatus};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Tsify)]
 #[cfg_attr(test, derive(serde::Deserialize))]
@@ -18,6 +18,7 @@ pub struct PrItemDto {
     pub is_draft: bool,
     pub approval_status: ApprovalStatus,
     pub ci_status: CiStatus,
+    pub mergeable_status: MergeableStatus,
     pub additions: u32,
     pub deletions: u32,
     /// ISO 8601 形式の文字列。chrono 不使用で WASM バイナリサイズを削減。
@@ -38,6 +39,7 @@ impl From<PullRequest> for PrItemDto {
             is_draft,
             approval_status,
             ci_status,
+            mergeable_status,
             additions,
             deletions,
             created_at,
@@ -53,6 +55,7 @@ impl From<PullRequest> for PrItemDto {
             is_draft,
             approval_status,
             ci_status,
+            mergeable_status,
             additions,
             deletions,
             created_at,
@@ -75,7 +78,7 @@ pub struct PrListDto {
 #[cfg(test)]
 mod tests {
     use crate::dto::{PrItemDto, PrListDto};
-    use domain::status::{ApprovalStatus, CiStatus};
+    use domain::status::{ApprovalStatus, CiStatus, MergeableStatus};
 
     fn make_pr_item() -> PrItemDto {
         PrItemDto {
@@ -88,6 +91,7 @@ mod tests {
             is_draft: false,
             approval_status: ApprovalStatus::Approved,
             ci_status: CiStatus::Passed,
+            mergeable_status: MergeableStatus::Unknown,
             additions: 100,
             deletions: 20,
             created_at: "2026-01-01T00:00:00Z".to_string(),
@@ -178,6 +182,7 @@ mod tests {
             true,
             ApprovalStatus::ChangesRequested,
             CiStatus::Failed,
+            MergeableStatus::Conflicting,
             250,
             80,
             "2026-03-01T12:00:00Z".to_string(),
@@ -196,6 +201,7 @@ mod tests {
         assert!(dto.is_draft);
         assert_eq!(dto.approval_status, ApprovalStatus::ChangesRequested);
         assert_eq!(dto.ci_status, CiStatus::Failed);
+        assert_eq!(dto.mergeable_status, MergeableStatus::Conflicting);
         assert_eq!(dto.additions, 250);
         assert_eq!(dto.deletions, 80);
         assert_eq!(dto.created_at, "2026-03-01T12:00:00Z");
@@ -229,6 +235,7 @@ mod tests {
                 false,
                 approval,
                 ci,
+                MergeableStatus::Unknown,
                 10,
                 5,
                 "2026-03-20T00:00:00Z".to_string(),

--- a/rust-core/crates/adapter-wasm/src/lib.rs
+++ b/rust-core/crates/adapter-wasm/src/lib.rs
@@ -95,7 +95,8 @@ mod tests {
                                 "additions": 10,
                                 "deletions": 5,
                                 "createdAt": "2026-01-01T00:00:00Z",
-                                "updatedAt": "2026-01-02T00:00:00Z"
+                                "updatedAt": "2026-01-02T00:00:00Z",
+                                "mergeable": null
                             }
                         }
                     ]
@@ -152,7 +153,8 @@ mod tests {
                                 "commits": { "nodes": [] },
                                 "repository": { "nameWithOwner": "o/r" },
                                 "createdAt": "2026-01-01T00:00:00Z",
-                                "updatedAt": "2026-01-02T00:00:00Z"
+                                "updatedAt": "2026-01-02T00:00:00Z",
+                                "mergeable": null
                             }
                         }
                     ]
@@ -171,7 +173,8 @@ mod tests {
                                 "commits": { "nodes": [] },
                                 "repository": { "nameWithOwner": "o/r" },
                                 "createdAt": "2026-01-01T00:00:00Z",
-                                "updatedAt": "2026-01-03T00:00:00Z"
+                                "updatedAt": "2026-01-03T00:00:00Z",
+                                "mergeable": null
                             }
                         }
                     ]

--- a/rust-core/crates/adapter-wasm/src/parser.rs
+++ b/rust-core/crates/adapter-wasm/src/parser.rs
@@ -46,6 +46,7 @@ pub struct PrNode {
     pub deletions: Option<u32>,
     pub created_at: String,
     pub updated_at: String,
+    pub mergeable: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -136,6 +137,9 @@ pub fn convert_node_to_pull_request(node: PrNode) -> Result<PullRequest, WasmErr
         .map(|rollup| rollup.state.as_str());
     let ci_status = usecase::determine::determine_ci_status(ci_state)?;
 
+    let mergeable_status =
+        usecase::determine::determine_mergeable_status(node.mergeable.as_deref())?;
+
     let pr = PullRequest::new(
         node.id,
         node.number,
@@ -146,6 +150,7 @@ pub fn convert_node_to_pull_request(node: PrNode) -> Result<PullRequest, WasmErr
         node.is_draft,
         approval_status,
         ci_status,
+        mergeable_status,
         node.additions.unwrap_or(0),
         node.deletions.unwrap_or(0),
         node.created_at,
@@ -192,7 +197,8 @@ mod tests {
                                 "additions": 100,
                                 "deletions": 20,
                                 "createdAt": "2026-01-01T00:00:00Z",
-                                "updatedAt": "2026-01-02T00:00:00Z"
+                                "updatedAt": "2026-01-02T00:00:00Z",
+                                "mergeable": null
                             }
                         }
                     ]
@@ -264,7 +270,8 @@ mod tests {
                                 },
                                 "repository": { "nameWithOwner": "o/r" },
                                 "createdAt": "2026-01-01T00:00:00Z",
-                                "updatedAt": "2026-01-02T00:00:00Z"
+                                "updatedAt": "2026-01-02T00:00:00Z",
+                                "mergeable": null
                             }
                         }
                     ]
@@ -303,7 +310,8 @@ mod tests {
                                 },
                                 "repository": { "nameWithOwner": "o/r" },
                                 "createdAt": "2026-01-01T00:00:00Z",
-                                "updatedAt": "2026-01-02T00:00:00Z"
+                                "updatedAt": "2026-01-02T00:00:00Z",
+                                "mergeable": null
                             }
                         }
                     ]
@@ -336,7 +344,8 @@ mod tests {
                                 },
                                 "repository": { "nameWithOwner": "o/r" },
                                 "createdAt": "2026-01-01T00:00:00Z",
-                                "updatedAt": "2026-01-02T00:00:00Z"
+                                "updatedAt": "2026-01-02T00:00:00Z",
+                                "mergeable": null
                             }
                         }
                     ]
@@ -368,7 +377,8 @@ mod tests {
                                 "commits": { "nodes": [] },
                                 "repository": { "nameWithOwner": "o/r" },
                                 "createdAt": "2026-01-01T00:00:00Z",
-                                "updatedAt": "2026-01-02T00:00:00Z"
+                                "updatedAt": "2026-01-02T00:00:00Z",
+                                "mergeable": null
                             }
                         }
                     ]
@@ -410,7 +420,8 @@ mod tests {
                                 "commits": { "nodes": [] },
                                 "repository": { "nameWithOwner": "o/r" },
                                 "createdAt": "2026-01-01T00:00:00Z",
-                                "updatedAt": "2026-01-02T00:00:00Z"
+                                "updatedAt": "2026-01-02T00:00:00Z",
+                                "mergeable": null
                             }
                         }
                     ]
@@ -462,7 +473,8 @@ mod tests {
                                 "commits": { "nodes": [] },
                                 "repository": { "nameWithOwner": "o/r" },
                                 "createdAt": "2026-01-01T00:00:00Z",
-                                "updatedAt": "2026-01-02T00:00:00Z"
+                                "updatedAt": "2026-01-02T00:00:00Z",
+                                "mergeable": null
                             }
                         }
                     ]
@@ -494,7 +506,8 @@ mod tests {
                                 "commits": { "nodes": [] },
                                 "repository": { "nameWithOwner": "o/r" },
                                 "createdAt": "2026-01-01T00:00:00Z",
-                                "updatedAt": "2026-01-02T00:00:00Z"
+                                "updatedAt": "2026-01-02T00:00:00Z",
+                                "mergeable": null
                             }
                         }
                     ]
@@ -513,7 +526,8 @@ mod tests {
                                 "commits": { "nodes": [] },
                                 "repository": { "nameWithOwner": "o/r" },
                                 "createdAt": "2026-01-01T00:00:00Z",
-                                "updatedAt": "2026-01-03T00:00:00Z"
+                                "updatedAt": "2026-01-03T00:00:00Z",
+                                "mergeable": null
                             }
                         }
                     ]
@@ -557,7 +571,8 @@ mod tests {
                                 "commits": { "nodes": [] },
                                 "repository": { "nameWithOwner": "o/r" },
                                 "createdAt": "2026-01-01T00:00:00Z",
-                                "updatedAt": "2026-01-02T00:00:00Z"
+                                "updatedAt": "2026-01-02T00:00:00Z",
+                                "mergeable": null
                             }
                         }
                     ]
@@ -591,7 +606,8 @@ mod tests {
                                 "commits": { "nodes": [] },
                                 "repository": { "nameWithOwner": "o/r" },
                                 "createdAt": "2026-01-01T00:00:00Z",
-                                "updatedAt": "2026-01-02T00:00:00Z"
+                                "updatedAt": "2026-01-02T00:00:00Z",
+                                "mergeable": null
                             }
                         }
                     ]
@@ -635,7 +651,8 @@ mod tests {
                                 },
                                 "repository": { "nameWithOwner": "o/r" },
                                 "createdAt": "2026-01-01T00:00:00Z",
-                                "updatedAt": "2026-01-02T00:00:00Z"
+                                "updatedAt": "2026-01-02T00:00:00Z",
+                                "mergeable": null
                             }
                         }
                     ]
@@ -676,7 +693,8 @@ mod tests {
                                 },
                                 "repository": { "nameWithOwner": "o/r" },
                                 "createdAt": "2026-01-01T00:00:00Z",
-                                "updatedAt": "2026-01-02T00:00:00Z"
+                                "updatedAt": "2026-01-02T00:00:00Z",
+                                "mergeable": null
                             }
                         }
                     ]
@@ -717,7 +735,8 @@ mod tests {
                                 },
                                 "repository": { "nameWithOwner": "o/r" },
                                 "createdAt": "2026-01-01T00:00:00Z",
-                                "updatedAt": "2026-01-02T00:00:00Z"
+                                "updatedAt": "2026-01-02T00:00:00Z",
+                                "mergeable": null
                             }
                         }
                     ]
@@ -758,7 +777,8 @@ mod tests {
                                 },
                                 "repository": { "nameWithOwner": "o/r" },
                                 "createdAt": "2026-01-01T00:00:00Z",
-                                "updatedAt": "2026-01-02T00:00:00Z"
+                                "updatedAt": "2026-01-02T00:00:00Z",
+                                "mergeable": null
                             }
                         }
                     ]
@@ -790,7 +810,8 @@ mod tests {
                                 "commits": { "nodes": [] },
                                 "repository": { "nameWithOwner": "o/r" },
                                 "createdAt": "2026-01-01T00:00:00Z",
-                                "updatedAt": "2026-01-02T00:00:00Z"
+                                "updatedAt": "2026-01-02T00:00:00Z",
+                                "mergeable": null
                             }
                         }
                     ]
@@ -822,7 +843,8 @@ mod tests {
                                 "commits": { "nodes": [] },
                                 "repository": { "nameWithOwner": "o/r" },
                                 "createdAt": "2026-01-01T00:00:00Z",
-                                "updatedAt": "2026-01-02T00:00:00Z"
+                                "updatedAt": "2026-01-02T00:00:00Z",
+                                "mergeable": null
                             }
                         }
                     ]

--- a/rust-core/crates/domain/src/entity.rs
+++ b/rust-core/crates/domain/src/entity.rs
@@ -1,6 +1,6 @@
 use serde::Serialize;
 
-use crate::status::{ApprovalStatus, CiStatus};
+use crate::status::{ApprovalStatus, CiStatus, MergeableStatus};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -14,6 +14,7 @@ pub struct PullRequest {
     is_draft: bool,
     approval_status: ApprovalStatus,
     ci_status: CiStatus,
+    mergeable_status: MergeableStatus,
     additions: u32,
     deletions: u32,
     /// ISO 8601 形式の文字列 (例: "2026-01-01T00:00:00Z")。
@@ -37,6 +38,7 @@ impl PullRequest {
         is_draft: bool,
         approval_status: ApprovalStatus,
         ci_status: CiStatus,
+        mergeable_status: MergeableStatus,
         additions: u32,
         deletions: u32,
         created_at: String,
@@ -110,6 +112,7 @@ impl PullRequest {
             is_draft,
             approval_status,
             ci_status,
+            mergeable_status,
             additions,
             deletions,
             created_at,
@@ -153,6 +156,10 @@ impl PullRequest {
         self.ci_status
     }
 
+    pub fn mergeable_status(&self) -> MergeableStatus {
+        self.mergeable_status
+    }
+
     pub fn additions(&self) -> u32 {
         self.additions
     }
@@ -184,6 +191,7 @@ impl PullRequest {
         bool,
         ApprovalStatus,
         CiStatus,
+        MergeableStatus,
         u32,
         u32,
         String,
@@ -199,6 +207,7 @@ impl PullRequest {
             self.is_draft,
             self.approval_status,
             self.ci_status,
+            self.mergeable_status,
             self.additions,
             self.deletions,
             self.created_at,
@@ -211,7 +220,7 @@ impl PullRequest {
 mod tests {
     use super::*;
     use crate::error::DomainError;
-    use crate::status::{ApprovalStatus, CiStatus};
+    use crate::status::{ApprovalStatus, CiStatus, MergeableStatus};
 
     /// ヘルパー: バリデーション付きコンストラクタで有効な PR を生成。
     /// テスト内で `.expect()` を個別に呼ばなくて済むよう、ここで unwrap する。
@@ -226,6 +235,7 @@ mod tests {
             false,
             ApprovalStatus::Approved,
             CiStatus::Passed,
+            MergeableStatus::Unknown,
             100,
             20,
             "2026-01-01T00:00:00Z".to_string(),
@@ -243,6 +253,7 @@ mod tests {
         assert!(!pr.is_draft());
         assert_eq!(pr.approval_status(), ApprovalStatus::Approved);
         assert_eq!(pr.ci_status(), CiStatus::Passed);
+        assert_eq!(pr.mergeable_status(), MergeableStatus::Unknown);
     }
 
     #[test]
@@ -266,6 +277,7 @@ mod tests {
         assert!(json.contains("\"isDraft\""));
         assert!(json.contains("\"approvalStatus\""));
         assert!(json.contains("\"ciStatus\""));
+        assert!(json.contains("\"mergeableStatus\""));
         assert!(json.contains("\"createdAt\""));
         assert!(json.contains("\"updatedAt\""));
     }
@@ -291,6 +303,7 @@ mod tests {
             false,
             ApprovalStatus::Approved,
             CiStatus::Passed,
+            MergeableStatus::Unknown,
             100,
             20,
             "2026-01-01T00:00:00Z".to_string(),
@@ -311,6 +324,7 @@ mod tests {
             false,
             ApprovalStatus::Approved,
             CiStatus::Passed,
+            MergeableStatus::Unknown,
             0,
             0,
             "2026-01-01T00:00:00Z".to_string(),
@@ -335,6 +349,7 @@ mod tests {
             false,
             ApprovalStatus::Pending,
             CiStatus::None,
+            MergeableStatus::Unknown,
             0,
             0,
             "2026-01-01T00:00:00Z".to_string(),
@@ -359,6 +374,7 @@ mod tests {
             false,
             ApprovalStatus::Pending,
             CiStatus::None,
+            MergeableStatus::Unknown,
             0,
             0,
             "2026-01-01T00:00:00Z".to_string(),
@@ -383,6 +399,7 @@ mod tests {
             false,
             ApprovalStatus::Pending,
             CiStatus::None,
+            MergeableStatus::Unknown,
             0,
             0,
             "2026-01-01T00:00:00Z".to_string(),
@@ -407,6 +424,7 @@ mod tests {
             false,
             ApprovalStatus::Pending,
             CiStatus::None,
+            MergeableStatus::Unknown,
             0,
             0,
             "2026-01-01T00:00:00Z".to_string(),
@@ -431,6 +449,7 @@ mod tests {
             false,
             ApprovalStatus::Pending,
             CiStatus::None,
+            MergeableStatus::Unknown,
             0,
             0,
             "".to_string(),
@@ -455,6 +474,7 @@ mod tests {
             false,
             ApprovalStatus::Pending,
             CiStatus::None,
+            MergeableStatus::Unknown,
             0,
             0,
             "2026-01-01T00:00:00Z".to_string(),
@@ -479,6 +499,7 @@ mod tests {
             false,
             ApprovalStatus::Pending,
             CiStatus::None,
+            MergeableStatus::Unknown,
             0,
             0,
             "2026-01-01T00:00:00Z".to_string(),
@@ -503,6 +524,7 @@ mod tests {
             false,
             ApprovalStatus::Pending,
             CiStatus::None,
+            MergeableStatus::Unknown,
             0,
             0,
             "2026-01-01T00:00:00Z".to_string(),
@@ -527,6 +549,7 @@ mod tests {
             false,
             ApprovalStatus::Pending,
             CiStatus::None,
+            MergeableStatus::Unknown,
             0,
             0,
             "2026-01-01T00:00:00Z".to_string(),
@@ -550,6 +573,7 @@ mod tests {
             false,
             ApprovalStatus::Pending,
             CiStatus::None,
+            MergeableStatus::Unknown,
             0,
             0,
             "2026-01-01T00:00:00Z".to_string(),
@@ -573,6 +597,7 @@ mod tests {
             false,
             ApprovalStatus::Pending,
             CiStatus::None,
+            MergeableStatus::Unknown,
             0,
             0,
             "2026-01-01T00:00:00Z".to_string(),
@@ -593,6 +618,7 @@ mod tests {
         assert!(!pr.is_draft());
         assert_eq!(pr.approval_status(), ApprovalStatus::Approved);
         assert_eq!(pr.ci_status(), CiStatus::Passed);
+        assert_eq!(pr.mergeable_status(), MergeableStatus::Unknown);
         assert_eq!(pr.additions(), 100);
         assert_eq!(pr.deletions(), 20);
         assert_eq!(pr.created_at(), "2026-01-01T00:00:00Z");

--- a/rust-core/crates/domain/src/status.rs
+++ b/rust-core/crates/domain/src/status.rs
@@ -26,6 +26,16 @@ pub enum CiStatus {
     None,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum MergeableStatus {
+    /// マージ可能。コンフリクトなし。
+    Mergeable,
+    /// コンフリクトあり。
+    Conflicting,
+    /// マージ可能性が未確定 (GitHub が計算中)。
+    Unknown,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -79,6 +89,31 @@ mod tests {
         let original = CiStatus::Failed;
         let copied = original;
         let cloned = original.clone();
+        assert_eq!(original, copied);
+        assert_eq!(original, cloned);
+    }
+
+    #[test]
+    fn mergeable_status_serde_roundtrip() {
+        let variants = [
+            MergeableStatus::Mergeable,
+            MergeableStatus::Conflicting,
+            MergeableStatus::Unknown,
+        ];
+        for variant in &variants {
+            let json = serde_json::to_string(variant).expect("serialize should succeed");
+            let restored: MergeableStatus =
+                serde_json::from_str(&json).expect("deserialize should succeed");
+            assert_eq!(*variant, restored);
+        }
+    }
+
+    #[test]
+    #[allow(clippy::clone_on_copy)]
+    fn mergeable_status_copy_clone() {
+        let original = MergeableStatus::Conflicting;
+        let copied = original; // Copy
+        let cloned = original.clone(); // Clone
         assert_eq!(original, copied);
         assert_eq!(original, cloned);
     }

--- a/rust-core/crates/usecase/src/determine.rs
+++ b/rust-core/crates/usecase/src/determine.rs
@@ -1,5 +1,5 @@
 use domain::error::DomainError;
-use domain::status::{ApprovalStatus, CiStatus};
+use domain::status::{ApprovalStatus, CiStatus, MergeableStatus};
 
 pub fn determine_approval_status(
     review_decision: Option<&str>,
@@ -30,11 +30,24 @@ pub fn determine_ci_status(status_check_rollup: Option<&str>) -> Result<CiStatus
     }
 }
 
+pub fn determine_mergeable_status(mergeable: Option<&str>) -> Result<MergeableStatus, DomainError> {
+    match mergeable {
+        None => Ok(MergeableStatus::Unknown),
+        Some("MERGEABLE") => Ok(MergeableStatus::Mergeable),
+        Some("CONFLICTING") => Ok(MergeableStatus::Conflicting),
+        Some("UNKNOWN") => Ok(MergeableStatus::Unknown),
+        Some(other) => Err(DomainError::InvalidField {
+            field: "mergeable".into(),
+            reason: format!("unknown mergeable status: {other}"),
+        }),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use domain::error::DomainError;
-    use domain::status::{ApprovalStatus, CiStatus};
+    use domain::status::{ApprovalStatus, CiStatus, MergeableStatus};
 
     // --- determine_approval_status ---
 
@@ -163,5 +176,66 @@ mod tests {
             }
             other => panic!("expected InvalidField error, got {other:?}"),
         }
+    }
+
+    // --- determine_mergeable_status ---
+
+    #[test]
+    fn mergeable_status_mergeable() {
+        let result =
+            determine_mergeable_status(Some("MERGEABLE")).expect("MERGEABLE should be valid");
+        assert_eq!(result, MergeableStatus::Mergeable);
+    }
+
+    #[test]
+    fn mergeable_status_conflicting() {
+        let result =
+            determine_mergeable_status(Some("CONFLICTING")).expect("CONFLICTING should be valid");
+        assert_eq!(result, MergeableStatus::Conflicting);
+    }
+
+    #[test]
+    fn mergeable_status_unknown() {
+        let result = determine_mergeable_status(Some("UNKNOWN")).expect("UNKNOWN should be valid");
+        assert_eq!(result, MergeableStatus::Unknown);
+    }
+
+    #[test]
+    fn mergeable_status_none_returns_unknown() {
+        let result = determine_mergeable_status(None).expect("None should map to Unknown");
+        assert_eq!(result, MergeableStatus::Unknown);
+    }
+
+    #[test]
+    fn mergeable_status_invalid_value_returns_error() {
+        let result = determine_mergeable_status(Some("INVALID_VALUE"));
+        assert!(result.is_err(), "invalid value should return an error");
+        match result {
+            Err(DomainError::InvalidField { field, .. }) => {
+                assert_eq!(field, "mergeable");
+            }
+            other => panic!("expected InvalidField error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn mergeable_status_empty_string_returns_error() {
+        let result = determine_mergeable_status(Some(""));
+        assert!(result.is_err(), "empty string should return an error");
+        match result {
+            Err(DomainError::InvalidField { field, .. }) => {
+                assert_eq!(field, "mergeable");
+            }
+            other => panic!("expected InvalidField error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn mergeable_status_lowercase_returns_error() {
+        let result = determine_mergeable_status(Some("mergeable"));
+        assert!(
+            result.is_err(),
+            "lowercase should return an error (only uppercase accepted)"
+        );
     }
 }

--- a/rust-core/crates/usecase/src/process.rs
+++ b/rust-core/crates/usecase/src/process.rs
@@ -24,7 +24,7 @@ pub fn process_pull_requests(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use domain::status::{ApprovalStatus, CiStatus};
+    use domain::status::{ApprovalStatus, CiStatus, MergeableStatus};
 
     fn make_pr(author: &str, number: u32, updated_at: &str) -> PullRequest {
         PullRequest::new(
@@ -37,6 +37,7 @@ mod tests {
             false,
             ApprovalStatus::Approved,
             CiStatus::Passed,
+            MergeableStatus::Unknown,
             10,
             5,
             "2026-01-01T00:00:00Z".to_string(),

--- a/rust-core/crates/usecase/src/sort.rs
+++ b/rust-core/crates/usecase/src/sort.rs
@@ -7,7 +7,7 @@ pub fn sort_by_updated_at_desc(pull_requests: &mut [PullRequest]) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use domain::status::{ApprovalStatus, CiStatus};
+    use domain::status::{ApprovalStatus, CiStatus, MergeableStatus};
 
     fn make_pr(number: u32, updated_at: &str) -> PullRequest {
         PullRequest::new(
@@ -20,6 +20,7 @@ mod tests {
             false,
             ApprovalStatus::Approved,
             CiStatus::Passed,
+            MergeableStatus::Unknown,
             10,
             5,
             "2026-01-01T00:00:00Z".to_string(),

--- a/src/adapter/github/graphql-client.ts
+++ b/src/adapter/github/graphql-client.ts
@@ -55,6 +55,7 @@ fragment PrFields on PullRequest {
   }
   createdAt
   updatedAt
+  mergeable
 }`;
 
 const PULL_REQUESTS_QUERY = `

--- a/src/domain/ports/pr-processor.port.ts
+++ b/src/domain/ports/pr-processor.port.ts
@@ -1,5 +1,6 @@
 export type ApprovalStatus = "Approved" | "ChangesRequested" | "ReviewRequired" | "Pending";
 export type CiStatus = "Passed" | "Failed" | "Running" | "Pending" | "None";
+export type MergeableStatus = "Mergeable" | "Conflicting" | "Unknown";
 
 /** Rust の domain::dto::PrItemDto に対応する TypeScript 型 */
 export interface PrItemDto {
@@ -12,6 +13,7 @@ export interface PrItemDto {
 	readonly isDraft: boolean;
 	readonly approvalStatus: ApprovalStatus;
 	readonly ciStatus: CiStatus;
+	readonly mergeableStatus: MergeableStatus;
 	readonly additions: number;
 	readonly deletions: number;
 	readonly createdAt: string;

--- a/src/shared/types/wasm.ts
+++ b/src/shared/types/wasm.ts
@@ -7,6 +7,7 @@ export interface Greeting {
 export type {
 	ApprovalStatus,
 	CiStatus,
+	MergeableStatus,
 	PrItemDto,
 	PrListDto,
 } from "../../domain/ports/pr-processor.port";

--- a/src/sidepanel/components/MergeableBadge.svelte
+++ b/src/sidepanel/components/MergeableBadge.svelte
@@ -1,0 +1,47 @@
+<script lang="ts">
+	import type { MergeableStatus } from "../../shared/types/wasm";
+	import "../styles/badge.css";
+
+	type Props = {
+		mergeableStatus: MergeableStatus;
+	};
+
+	const { mergeableStatus }: Props = $props();
+
+	// "Mergeable" (コンフリクトなし) は正常状態のためノイズ削減で非表示。
+	// config に存在しないキーは $derived で undefined → {#if resolved} で非表示になる。
+	const config: Record<string, { label: string; colorClass: string; animate: boolean }> = {
+		Conflicting: { label: "CONFLICT", colorClass: "badge-red", animate: false },
+		Unknown: { label: "CHECKING...", colorClass: "badge-gray", animate: true },
+	};
+
+	const resolved = $derived(config[mergeableStatus]);
+</script>
+
+{#if resolved}
+	<span class="badge {resolved.colorClass}" class:badge-animate={resolved.animate}
+		>{resolved.label}</span
+	>
+{/if}
+
+<style>
+	.badge-animate {
+		animation: pulse 1.5s ease-in-out infinite;
+	}
+
+	@keyframes pulse {
+		0%,
+		100% {
+			opacity: 1;
+		}
+		50% {
+			opacity: 0.5;
+		}
+	}
+
+	@media (prefers-reduced-motion: reduce) {
+		.badge-animate {
+			animation: none;
+		}
+	}
+</style>

--- a/src/sidepanel/components/PrItem.svelte
+++ b/src/sidepanel/components/PrItem.svelte
@@ -3,6 +3,7 @@
 	import { safeUrl } from "../../shared/utils/url";
 	import ApprovalBadge from "./ApprovalBadge.svelte";
 	import CiBadge from "./CiBadge.svelte";
+	import MergeableBadge from "./MergeableBadge.svelte";
 	import DraftBadge from "./DraftBadge.svelte";
 	import RelativeTime from "./RelativeTime.svelte";
 
@@ -27,6 +28,7 @@
 		{#if !pr.isDraft}
 			<ApprovalBadge approvalStatus={pr.approvalStatus} />
 			<CiBadge ciStatus={pr.ciStatus} />
+			<MergeableBadge mergeableStatus={pr.mergeableStatus} />
 		{/if}
 	</div>
 </div>

--- a/src/test/shared/usecase/auto-refresh.usecase.test.ts
+++ b/src/test/shared/usecase/auto-refresh.usecase.test.ts
@@ -34,6 +34,7 @@ describe("auto-refresh usecase", () => {
 					isDraft: false,
 					approvalStatus: "Approved",
 					ciStatus: "Passed",
+					mergeableStatus: "Unknown",
 					additions: 10,
 					deletions: 5,
 					createdAt: "2026-03-20T00:00:00Z",

--- a/src/test/shared/usecase/pr.usecase.test.ts
+++ b/src/test/shared/usecase/pr.usecase.test.ts
@@ -25,6 +25,7 @@ describe("pr usecase", () => {
 					isDraft: false,
 					approvalStatus: "Approved",
 					ciStatus: "Passed",
+					mergeableStatus: "Unknown",
 					additions: 10,
 					deletions: 5,
 					createdAt: "2026-03-20T00:00:00Z",

--- a/src/test/sidepanel/components/MergeableBadge.test.ts
+++ b/src/test/sidepanel/components/MergeableBadge.test.ts
@@ -1,0 +1,78 @@
+// RED phase test: MergeableBadge.svelte
+// 配置先: src/test/sidepanel/components/MergeableBadge.test.ts
+//
+// 前提:
+//   - MergeableStatus 型が src/shared/types/wasm.ts から export されていること
+//   - MergeableBadge.svelte が src/sidepanel/components/ に存在すること
+
+import { mount, unmount } from "svelte";
+import { afterEach, describe, expect, it } from "vitest";
+import type { MergeableStatus } from "../../../shared/types/wasm";
+import MergeableBadge from "../../../sidepanel/components/MergeableBadge.svelte";
+
+/** テスト専用: 型チェックを迂回して不正値を注入する */
+function unsafeCast<T>(value: unknown): T {
+	return value as T;
+}
+
+describe("MergeableBadge", () => {
+	let component: ReturnType<typeof mount>;
+
+	afterEach(() => {
+		if (component) {
+			unmount(component);
+		}
+		document.body.innerHTML = "";
+	});
+
+	it("should render CONFLICT badge with red class when status is Conflicting", () => {
+		component = mount(MergeableBadge, {
+			target: document.body,
+			props: { mergeableStatus: "Conflicting" },
+		});
+		const badge = document.querySelector(".badge");
+		expect(badge).not.toBeNull();
+		expect(badge?.textContent?.trim()).toBe("CONFLICT");
+		expect(badge?.classList.contains("badge-red")).toBe(true);
+		expect(badge?.classList.contains("badge-animate")).toBe(false);
+	});
+
+	it("should render CHECKING... badge with gray class and animation when status is Unknown", () => {
+		component = mount(MergeableBadge, {
+			target: document.body,
+			props: { mergeableStatus: "Unknown" },
+		});
+		const badge = document.querySelector(".badge");
+		expect(badge).not.toBeNull();
+		expect(badge?.textContent?.trim()).toBe("CHECKING...");
+		expect(badge?.classList.contains("badge-gray")).toBe(true);
+		expect(badge?.classList.contains("badge-animate")).toBe(true);
+	});
+
+	it("should render nothing when status is Mergeable (normal state, no noise)", () => {
+		component = mount(MergeableBadge, {
+			target: document.body,
+			props: { mergeableStatus: "Mergeable" },
+		});
+		const badge = document.querySelector(".badge");
+		expect(badge).toBeNull();
+	});
+
+	it("should render nothing when status is an empty string", () => {
+		component = mount(MergeableBadge, {
+			target: document.body,
+			props: { mergeableStatus: unsafeCast<MergeableStatus>("") },
+		});
+		const badge = document.querySelector(".badge");
+		expect(badge).toBeNull();
+	});
+
+	it("should render nothing when status is an unknown value", () => {
+		component = mount(MergeableBadge, {
+			target: document.body,
+			props: { mergeableStatus: unsafeCast<MergeableStatus>("InvalidValue") },
+		});
+		const badge = document.querySelector(".badge");
+		expect(badge).toBeNull();
+	});
+});

--- a/src/test/sidepanel/components/PrItem.test.ts
+++ b/src/test/sidepanel/components/PrItem.test.ts
@@ -14,6 +14,7 @@ function createPrItemDto(overrides: Partial<PrItemDto> = {}): PrItemDto {
 		isDraft: false,
 		approvalStatus: "ReviewRequired",
 		ciStatus: "Passed",
+		mergeableStatus: "Unknown",
 		additions: 10,
 		deletions: 3,
 		createdAt: "2026-03-20T10:00:00Z",


### PR DESCRIPTION
## 概要
PR 一覧にコンフリクト状態（Mergeable / Conflicting / Unknown）のバッジを表示する機能を追加。GitHub GraphQL API の `mergeable` フィールドを取得し、Rust/WASM で状態判定、Svelte でバッジ表示する。

## 変更内容
- `rust-core/crates/domain/src/status.rs`: `MergeableStatus` enum (Mergeable/Conflicting/Unknown) を追加
- `rust-core/crates/domain/src/entity.rs`: `PullRequest` に `mergeable_status` フィールド、getter、`into_parts()` 更新
- `rust-core/crates/usecase/src/determine.rs`: `determine_mergeable_status()` 関数を追加（GraphQL 値 → enum マッピング）
- `rust-core/crates/usecase/src/process.rs`, `sort.rs`: テストヘルパー更新
- `rust-core/crates/adapter-wasm/src/dto.rs`: `PrItemDto` に `mergeable_status` フィールド追加
- `rust-core/crates/adapter-wasm/src/parser.rs`: `PrNode` に `mergeable` フィールド追加、パース処理
- `rust-core/crates/adapter-wasm/src/lib.rs`: テスト JSON フィクスチャ更新
- `src/adapter/github/graphql-client.ts`: `PR_FIELDS_FRAGMENT` に `mergeable` フィールド追加
- `src/domain/ports/pr-processor.port.ts`: `MergeableStatus` 型、`PrItemDto` にフィールド追加
- `src/shared/types/wasm.ts`: `MergeableStatus` re-export 追加
- `src/sidepanel/components/MergeableBadge.svelte`: 新規コンポーネント（Conflicting → 赤バッジ、Unknown → グレー+アニメーション、Mergeable → 非表示）
- `src/sidepanel/components/PrItem.svelte`: MergeableBadge を追加
- `src/test/sidepanel/components/MergeableBadge.test.ts`: 新規テスト（5ケース）
- `src/test/sidepanel/components/PrItem.test.ts`, `auto-refresh.usecase.test.ts`, `pr.usecase.test.ts`: テスト更新

## 関連 Issue
- closes #180

## テスト
- [x] TypeScript 型チェック通過 (`pnpm check`)
- [x] フロントエンドテスト通過 (`pnpm test`) — 41 files, 494 tests
- [x] Rust lint 通過 (`cargo clippy --all-targets`)
- [x] Rust テスト通過 (`cargo test`) — 37 tests
- [x] `/verify` で検証ループ PASS

## レビュー観点
- `MergeableStatus` が既存の `ApprovalStatus`/`CiStatus` パターンと一貫しているか
- `UNKNOWN` 状態の表示方針（"CHECKING..." + アニメーション）が妥当か
- `Mergeable` を非表示にする判断（正常状態のノイズ削減）が適切か
- GraphQL `mergeable` フィールドの遅延計算（初回 UNKNOWN → 次回更新で確定）への対応が十分か