### PR TITLE
feat: PR番号をタイトル末尾に移動して薄く表示する

### DIFF
--- a/src/sidepanel/components/PrItem.svelte
+++ b/src/sidepanel/components/PrItem.svelte
@@ -31,7 +31,7 @@
 <!-- svelte-ignore a11y_no_static_element_interactions -->
 <div class="pr-item" class:active={isActive} onclick={handleClick}>
 	<a class="pr-title" href={safeUrl(pr.url)} target="_blank" rel="noopener noreferrer">
-		#{pr.number} {pr.title}
+		{pr.title} <span class="pr-number">#{pr.number}</span>
 	</a>
 	<div class="pr-meta">
 		<span class="pr-author">{pr.author}</span>
@@ -91,6 +91,11 @@
 		text-overflow: ellipsis;
 		white-space: nowrap;
 		flex-shrink: 0;
+	}
+
+	.pr-number {
+		color: var(--color-text-secondary);
+		margin-left: 0.25rem;
 	}
 
 	.pr-badges {

--- a/src/test/sidepanel/components/PrItem.test.ts
+++ b/src/test/sidepanel/components/PrItem.test.ts
@@ -44,14 +44,39 @@ describe("PrItem", () => {
 		expect(authorEl?.textContent?.trim()).toBe("testuser");
 	});
 
-	it("should display the PR number and title", () => {
+	it("should display the PR title followed by the PR number", () => {
 		component = mount(PrItem, {
 			target: document.body,
 			props: { pr: createPrItemDto({ number: 99, title: "Fix bug Y" }) },
 		});
 		const titleEl = document.querySelector(".pr-title");
 		expect(titleEl).not.toBeNull();
-		expect(titleEl?.textContent?.trim()).toBe("#99 Fix bug Y");
+		// タイトルテキストが先に表示され、番号が後に続く (完全一致で検証)
+		const textContent = titleEl?.textContent?.trim() ?? "";
+		expect(textContent).toMatch(/^Fix bug Y\s*#99$/);
+	});
+
+	it("should render the PR number in a dedicated .pr-number element", () => {
+		// NOTE: 薄い色の表示は .pr-number クラスの CSS (color: var(--color-text-secondary)) で実現。DOM 構造テストで担保。
+		component = mount(PrItem, {
+			target: document.body,
+			props: { pr: createPrItemDto({ number: 99, title: "Fix bug Y" }) },
+		});
+		const numberEl = document.querySelector(".pr-number");
+		expect(numberEl).not.toBeNull();
+		expect(numberEl?.textContent?.trim()).toBe("#99");
+	});
+
+	it("should place .pr-number element after the title text within .pr-title", () => {
+		component = mount(PrItem, {
+			target: document.body,
+			props: { pr: createPrItemDto({ number: 99, title: "Fix bug Y" }) },
+		});
+		const titleEl = document.querySelector(".pr-title");
+		const numberEl = titleEl?.querySelector(".pr-number");
+		expect(numberEl).not.toBeNull();
+		// .pr-number は .pr-title の子要素として末尾に存在する
+		expect(titleEl?.lastElementChild).toBe(numberEl);
 	});
 
 	it("should display the repository name", () => {


### PR DESCRIPTION
## 概要\nPR一覧の各行で、PR番号（`#123`）をタイトル先頭から末尾に移動し、`--color-text-secondary` で薄く表示するようにした。Issue番号をタイトル先頭に書く運用での視認性を向上させる。\n\n## 変更内容\n- `src/sidepanel/components/PrItem.svelte`: テンプレートで PR 番号をタイトル末尾の `<span class=\"pr-number\">` に移動し、`.pr-number` スタイル（`color: var(--color-text-secondary)`, `margin-left: 0.25rem`）を追加\n- `src/test/sidepanel/components/PrItem.test.ts`: 既存テスト1件を新レイアウトに更新、新規テスト2件（`.pr-number` 要素の存在・DOM順序）を追加\n\n## 関連 Issue\n- closes #199\n\n## テスト\n- [x] TypeScript 型チェック通過 (`pnpm check`)\n- [x] フロントエンドテスト通過 (`pnpm test`) — 555 tests passed\n- [x] Rust lint 通過 (`cargo clippy --all-targets`)\n- [x] Rust テスト通過 (`cargo test`) — 48 tests passed\n- [x] `/verify` で検証ループ PASS\n\n## レビュー観点\n- `.pr-number` の `color: var(--color-text-secondary)` が既存の `.pr-meta` 等と統一感があるか\n- タイトルが長い場合の折り返し時に PR 番号の位置が自然か"