### PR TITLE
fix: SizeBadge の色をサイズ依存からadditions緑/deletions赤に変更

### DIFF
--- a/src/sidepanel/components/PrItem.svelte
+++ b/src/sidepanel/components/PrItem.svelte
@@ -39,7 +39,7 @@
 		<span class="pr-updated"><RelativeTime dateStr={pr.updatedAt} /></span>
 	</div>
 	<div class="pr-badges">
-		<SizeBadge sizeLabel={pr.sizeLabel} additions={pr.additions} deletions={pr.deletions} />
+		<SizeBadge additions={pr.additions} deletions={pr.deletions} />
 		<DraftBadge isDraft={pr.isDraft} />
 		{#if !pr.isDraft}
 			<ApprovalBadge approvalStatus={pr.approvalStatus} />

--- a/src/sidepanel/components/SizeBadge.svelte
+++ b/src/sidepanel/components/SizeBadge.svelte
@@ -2,56 +2,12 @@
 	import "../styles/badge.css";
 
 	type Props = Readonly<{
-		sizeLabel: string;
 		additions: number;
 		deletions: number;
 	}>;
 
-	const { sizeLabel, additions, deletions }: Props = $props();
-
-	const cssClassMap: Record<string, string> = {
-		XS: "size-xs",
-		S: "size-s",
-		M: "size-m",
-		L: "size-l",
-		XL: "size-xl",
-	};
-
-	const cssClass = $derived(sizeLabel ? cssClassMap[sizeLabel] : undefined);
+	const { additions, deletions }: Props = $props();
 </script>
 
-{#if cssClass}
-	<span class="size-badge {cssClass}">+{additions} -{deletions}</span>
-{/if}
-
-<style>
-	.size-badge {
-		display: inline-block;
-		padding: 0.125rem 0.375rem;
-		border-radius: 9999px;
-		font-size: 0.625rem;
-		font-weight: 600;
-		color: var(--color-badge-text, #fff);
-		line-height: 1.4;
-	}
-
-	.size-xs {
-		background-color: var(--color-size-xs, #3fb950);
-	}
-
-	.size-s {
-		background-color: var(--color-size-s, #56d364);
-	}
-
-	.size-m {
-		background-color: var(--color-size-m, #d29922);
-	}
-
-	.size-l {
-		background-color: var(--color-size-l, #f85149);
-	}
-
-	.size-xl {
-		background-color: var(--color-size-xl, #da3633);
-	}
-</style>
+<span class="badge badge-green">+{additions}</span>
+<span class="badge badge-red">-{deletions}</span>

--- a/src/test/sidepanel/components/SizeBadge.test.ts
+++ b/src/test/sidepanel/components/SizeBadge.test.ts
@@ -2,11 +2,6 @@ import { mount, unmount } from "svelte";
 import { afterEach, describe, expect, it } from "vitest";
 import SizeBadge from "../../../sidepanel/components/SizeBadge.svelte";
 
-/** テスト専用: 型チェックを迂回して不正値を注入する */
-function unsafeCast<T>(value: unknown): T {
-	return value as T;
-}
-
 describe("SizeBadge", () => {
 	let component: ReturnType<typeof mount>;
 
@@ -17,103 +12,72 @@ describe("SizeBadge", () => {
 		document.body.innerHTML = "";
 	});
 
-	it("should render additions and deletions with size-xs class for XS", () => {
+	it("should render additions in .badge-green and deletions in .badge-red", () => {
 		component = mount(SizeBadge, {
 			target: document.body,
-			props: { sizeLabel: "XS", additions: 3, deletions: 2 },
+			props: { additions: 3, deletions: 2 },
 		});
-		const badge = document.querySelector(".size-badge");
-		expect(badge).not.toBeNull();
-		expect(badge?.textContent?.trim()).toBe("+3 -2");
-		expect(badge?.classList.contains("size-xs")).toBe(true);
+		const green = document.querySelector(".badge-green");
+		const red = document.querySelector(".badge-red");
+		expect(green).not.toBeNull();
+		expect(green?.textContent?.trim()).toBe("+3");
+		expect(red).not.toBeNull();
+		expect(red?.textContent?.trim()).toBe("-2");
 	});
 
-	it("should render additions and deletions with size-s class for S", () => {
+	it("should render +0 in .badge-green when additions is 0", () => {
 		component = mount(SizeBadge, {
 			target: document.body,
-			props: { sizeLabel: "S", additions: 20, deletions: 5 },
+			props: { additions: 0, deletions: 5 },
 		});
-		const badge = document.querySelector(".size-badge");
-		expect(badge).not.toBeNull();
-		expect(badge?.textContent?.trim()).toBe("+20 -5");
-		expect(badge?.classList.contains("size-s")).toBe(true);
+		const green = document.querySelector(".badge-green");
+		expect(green).not.toBeNull();
+		expect(green?.textContent?.trim()).toBe("+0");
 	});
 
-	it("should render additions and deletions with size-m class for M", () => {
+	it("should render -0 in .badge-red when deletions is 0", () => {
 		component = mount(SizeBadge, {
 			target: document.body,
-			props: { sizeLabel: "M", additions: 100, deletions: 50 },
+			props: { additions: 8, deletions: 0 },
 		});
-		const badge = document.querySelector(".size-badge");
-		expect(badge).not.toBeNull();
-		expect(badge?.textContent?.trim()).toBe("+100 -50");
-		expect(badge?.classList.contains("size-m")).toBe(true);
+		const red = document.querySelector(".badge-red");
+		expect(red).not.toBeNull();
+		expect(red?.textContent?.trim()).toBe("-0");
 	});
 
-	it("should render additions and deletions with size-l class for L", () => {
+	it("should render large values correctly", () => {
 		component = mount(SizeBadge, {
 			target: document.body,
-			props: { sizeLabel: "L", additions: 300, deletions: 100 },
+			props: { additions: 800, deletions: 200 },
 		});
-		const badge = document.querySelector(".size-badge");
-		expect(badge).not.toBeNull();
-		expect(badge?.textContent?.trim()).toBe("+300 -100");
-		expect(badge?.classList.contains("size-l")).toBe(true);
+		const green = document.querySelector(".badge-green");
+		const red = document.querySelector(".badge-red");
+		expect(green).not.toBeNull();
+		expect(green?.textContent?.trim()).toBe("+800");
+		expect(red).not.toBeNull();
+		expect(red?.textContent?.trim()).toBe("-200");
 	});
 
-	it("should render additions and deletions with size-xl class for XL", () => {
+	it("should render .badge-green and .badge-red with zero values", () => {
 		component = mount(SizeBadge, {
 			target: document.body,
-			props: { sizeLabel: "XL", additions: 800, deletions: 200 },
+			props: { additions: 0, deletions: 0 },
 		});
-		const badge = document.querySelector(".size-badge");
-		expect(badge).not.toBeNull();
-		expect(badge?.textContent?.trim()).toBe("+800 -200");
-		expect(badge?.classList.contains("size-xl")).toBe(true);
+		const green = document.querySelector(".badge-green");
+		const red = document.querySelector(".badge-red");
+		expect(green).not.toBeNull();
+		expect(red).not.toBeNull();
 	});
 
-	it("should render nothing when sizeLabel is an empty string", () => {
+	it("should not have any size-xs through size-xl classes in the DOM", () => {
 		component = mount(SizeBadge, {
 			target: document.body,
-			props: { sizeLabel: "", additions: 0, deletions: 0 },
+			props: { additions: 10, deletions: 5 },
 		});
-		const badge = document.querySelector(".size-badge");
-		expect(badge).toBeNull();
-	});
-
-	it("should render nothing when sizeLabel is an unknown value", () => {
-		component = mount(SizeBadge, {
-			target: document.body,
-			props: { sizeLabel: unsafeCast<string>("INVALID"), additions: 10, deletions: 5 },
-		});
-		const badge = document.querySelector(".size-badge");
-		expect(badge).toBeNull();
-	});
-
-	it("should render nothing when sizeLabel is undefined", () => {
-		component = mount(SizeBadge, {
-			target: document.body,
-			props: { sizeLabel: unsafeCast<string>(undefined), additions: 0, deletions: 0 },
-		});
-		const badge = document.querySelector(".size-badge");
-		expect(badge).toBeNull();
-	});
-
-	it("should handle zero additions", () => {
-		component = mount(SizeBadge, {
-			target: document.body,
-			props: { sizeLabel: "XS", additions: 0, deletions: 5 },
-		});
-		const badge = document.querySelector(".size-badge");
-		expect(badge?.textContent?.trim()).toBe("+0 -5");
-	});
-
-	it("should handle zero deletions", () => {
-		component = mount(SizeBadge, {
-			target: document.body,
-			props: { sizeLabel: "XS", additions: 8, deletions: 0 },
-		});
-		const badge = document.querySelector(".size-badge");
-		expect(badge?.textContent?.trim()).toBe("+8 -0");
+		expect(document.querySelector(".size-xs")).toBeNull();
+		expect(document.querySelector(".size-s")).toBeNull();
+		expect(document.querySelector(".size-m")).toBeNull();
+		expect(document.querySelector(".size-l")).toBeNull();
+		expect(document.querySelector(".size-xl")).toBeNull();
 	});
 });


### PR DESCRIPTION
## 概要\nSizeBadge のバッジ背景色をサイズラベル（XS/S/M/L/XL）ベースから、additions を緑 (.badge-green)・deletions を赤 (.badge-red) で個別表示する方式に変更。GitHub 本家と同様に `+N` を緑、`-N` を赤で示す直感的な表示にした。\n\n## 変更内容\n- `src/sidepanel/components/SizeBadge.svelte`: cssClassMap / $derived(cssClass) / {#if cssClass} 条件分岐 / scoped style (.size-badge, .size-xs~.size-xl) を全削除。badge.css の `.badge-green` / `.badge-red` を使う2つの span に置き換え。Props から `sizeLabel` を削除\n- `src/sidepanel/components/PrItem.svelte`: SizeBadge 呼び出しから `sizeLabel` prop を削除\n- `src/test/sidepanel/components/SizeBadge.test.ts`: 新仕様に合わせて全テストケースを書き換え (6テスト)。unsafeCast ヘルパーを削除\n\n## 関連 Issue\n- closes #201\n\n## テスト\n- [x] TypeScript 型チェック通過 (`pnpm check`)\n- [x] フロントエンドテスト通過 (`pnpm test`) — 549 tests passed\n- [x] Rust lint 通過 (`cargo clippy --all-targets`)\n- [x] Rust テスト通過 (`cargo test`) — 48 tests passed\n- [x] `/verify` で検証ループ PASS\n\n## レビュー観点\n- SizeBadge が sizeLabel に一切依存せず、additions/deletions のみで表示されること\n- badge.css の既存 `.badge-green` / `.badge-red` クラスの活用が適切か\n- PrItem.svelte の呼び出し側で sizeLabel prop 除去が正しく行われているか