### PR TITLE
feat: ログイン画面に github.com/login/device へのリンクを表示する

### DIFF
--- a/src/shared/usecase/device-flow.controller.ts
+++ b/src/shared/usecase/device-flow.controller.ts
@@ -11,6 +11,8 @@ const AUTH_ERROR_MESSAGES: Record<AuthErrorCode, string> = {
 };
 const FALLBACK_ERROR_MESSAGE = "エラーが発生しました。もう一度お試しください。";
 
+const ALLOWED_VERIFICATION_URI_PREFIX = "https://github.com/";
+
 function toUserFacingMessage(error: unknown): string {
 	if (error instanceof AuthError) {
 		return AUTH_ERROR_MESSAGES[error.code] ?? FALLBACK_ERROR_MESSAGE;
@@ -24,6 +26,7 @@ export type DeviceFlowController = {
 	readonly waitForAuthorization: () => Promise<void>;
 	readonly startAndWait: () => Promise<void>;
 	readonly subscribe: (listener: (state: DeviceFlowState) => void) => () => void;
+	readonly openVerificationUri: (uri: string) => void;
 };
 
 type PendingRequest = {
@@ -108,11 +111,18 @@ export function createDeviceFlowController(
 		};
 	}
 
+	function openVerificationUri(uri: string): void {
+		if (uri.startsWith(ALLOWED_VERIFICATION_URI_PREFIX)) {
+			chrome.tabs.create({ url: uri });
+		}
+	}
+
 	return {
 		getState: () => state,
 		startFlow,
 		waitForAuthorization,
 		startAndWait,
 		subscribe,
+		openVerificationUri,
 	};
 }

--- a/src/sidepanel/components/LoginScreen.svelte
+++ b/src/sidepanel/components/LoginScreen.svelte
@@ -10,13 +10,16 @@
 
 	let flowState = $state<DeviceFlowState>(controller.getState());
 	let inProgress = $state(false);
-	let lastUserCode = $state<string | null>(null);
+	const initialState = controller.getState();
+	let lastUserCode = $state<string | null>(initialState.phase === "awaiting_user" ? initialState.userCode : null);
+	let lastVerificationUri = $state<string | null>(initialState.phase === "awaiting_user" ? initialState.verificationUri : null);
 
 	$effect(() => {
 		return controller.subscribe((state) => {
 			flowState = state;
 			if (state.phase === "awaiting_user") {
 				lastUserCode = state.userCode;
+				lastVerificationUri = state.verificationUri;
 			}
 		});
 	});
@@ -39,8 +42,9 @@
 	}
 
 	function openVerificationUri() {
-		if (flowState.phase === "awaiting_user" && flowState.verificationUri.startsWith("https://")) {
-			window.open(flowState.verificationUri, "_blank");
+		const uri = flowState.phase === "awaiting_user" ? flowState.verificationUri : lastVerificationUri;
+		if (uri !== null && uri.startsWith("https://github.com/")) {
+			controller.openVerificationUri(uri);
 		}
 	}
 </script>
@@ -69,13 +73,14 @@
 				<button class="copy-btn" onclick={handleCopyCode}>Copy</button>
 			</div>
 
-			{#if flowState.phase === "awaiting_user"}
+			{#if flowState.phase === "awaiting_user" || (flowState.phase === "polling" && lastVerificationUri !== null)}
 				<a
 					class="verification-link"
-					href={flowState.verificationUri}
+					href={flowState.phase === "awaiting_user" ? flowState.verificationUri : lastVerificationUri}
+					rel="noopener noreferrer"
 					onclick={(e) => { e.preventDefault(); openVerificationUri(); }}
 				>
-					{flowState.verificationUri} を開く
+					{flowState.phase === "awaiting_user" ? flowState.verificationUri : lastVerificationUri} を開く
 				</a>
 			{/if}
 

--- a/src/test/sidepanel/components/LoginScreen.test.ts
+++ b/src/test/sidepanel/components/LoginScreen.test.ts
@@ -1,5 +1,6 @@
-import { mount, unmount } from "svelte";
+import { mount, tick, unmount } from "svelte";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { DeviceFlowState } from "../../../shared/usecase/auth.usecase";
 import type { DeviceFlowController } from "../../../shared/usecase/device-flow.controller";
 import LoginScreen from "../../../sidepanel/components/LoginScreen.svelte";
 
@@ -10,6 +11,7 @@ function createMockController(): DeviceFlowController {
 		waitForAuthorization: vi.fn(async () => {}),
 		startAndWait: vi.fn(async () => {}),
 		subscribe: vi.fn(() => () => {}),
+		openVerificationUri: vi.fn(),
 	};
 }
 
@@ -54,5 +56,151 @@ describe("LoginScreen", () => {
 		const buttons = document.querySelectorAll("button");
 		const loginButton = Array.from(buttons).find((btn) => btn.textContent?.includes("Login"));
 		expect(loginButton).not.toBeUndefined();
+	});
+
+	describe("verification link", () => {
+		const verificationUri = "https://github.com/login/device";
+		const userCode = "ABCD-1234";
+
+		let subscribeCallback: ((state: DeviceFlowState) => void) | undefined;
+
+		beforeEach(() => {
+			subscribeCallback = undefined;
+
+			mockController = {
+				...createMockController(),
+				getState: vi.fn(() => ({
+					phase: "awaiting_user" as const,
+					userCode,
+					verificationUri,
+				})),
+				subscribe: vi.fn((listener: (state: DeviceFlowState) => void) => {
+					subscribeCallback = listener;
+					return () => {
+						subscribeCallback = undefined;
+					};
+				}),
+			};
+		});
+
+		it("should display user code in awaiting_user state", async () => {
+			component = mount(LoginScreen, {
+				target: document.body,
+				props: { controller: mockController },
+			});
+			await tick();
+
+			const codeEl = document.querySelector(".user-code");
+			expect(codeEl?.textContent).toBe(userCode);
+		});
+
+		it("should display verification link in awaiting_user state", async () => {
+			component = mount(LoginScreen, {
+				target: document.body,
+				props: { controller: mockController },
+			});
+			await tick();
+
+			const link = document.querySelector("a.verification-link");
+			expect(link).not.toBeNull();
+		});
+
+		it("should display verification URI text in the link", async () => {
+			component = mount(LoginScreen, {
+				target: document.body,
+				props: { controller: mockController },
+			});
+			await tick();
+
+			const link = document.querySelector("a.verification-link");
+			expect(link).not.toBeNull();
+			expect(link?.textContent).toContain(verificationUri);
+		});
+
+		it("should have rel='noopener noreferrer' on verification link", async () => {
+			component = mount(LoginScreen, {
+				target: document.body,
+				props: { controller: mockController },
+			});
+			await tick();
+
+			const link = document.querySelector("a.verification-link") as HTMLAnchorElement;
+			expect(link).not.toBeNull();
+			expect(link.getAttribute("rel")).toBe("noopener noreferrer");
+		});
+
+		it("should call controller.openVerificationUri when verification link is clicked", async () => {
+			component = mount(LoginScreen, {
+				target: document.body,
+				props: { controller: mockController },
+			});
+			await tick();
+
+			const link = document.querySelector("a.verification-link") as HTMLAnchorElement;
+			expect(link).not.toBeNull();
+			link.click();
+			await tick();
+
+			expect(mockController.openVerificationUri).toHaveBeenCalledWith(verificationUri);
+		});
+
+		it("should keep verification link visible after transitioning to polling state", async () => {
+			component = mount(LoginScreen, {
+				target: document.body,
+				props: { controller: mockController },
+			});
+			await tick();
+
+			expect(subscribeCallback).toBeDefined();
+			subscribeCallback?.({ phase: "polling" });
+			await tick();
+
+			const link = document.querySelector("a.verification-link");
+			expect(link).not.toBeNull();
+		});
+
+		it("should not call controller.openVerificationUri when verificationUri is not https://github.com/", async () => {
+			const httpController: DeviceFlowController = {
+				...createMockController(),
+				getState: vi.fn(() => ({
+					phase: "awaiting_user" as const,
+					userCode,
+					verificationUri: "http://evil.com",
+				})),
+				subscribe: vi.fn((listener: (state: DeviceFlowState) => void) => {
+					subscribeCallback = listener;
+					return () => {
+						subscribeCallback = undefined;
+					};
+				}),
+			};
+			component = mount(LoginScreen, {
+				target: document.body,
+				props: { controller: httpController },
+			});
+			await tick();
+
+			const link = document.querySelector("a.verification-link") as HTMLAnchorElement;
+			expect(link).not.toBeNull();
+			link.click();
+			await tick();
+
+			expect(httpController.openVerificationUri).not.toHaveBeenCalled();
+		});
+
+		it("should not display verification link in idle state", async () => {
+			const idleController: DeviceFlowController = {
+				...createMockController(),
+				getState: vi.fn(() => ({ phase: "idle" as const })),
+			};
+			component = mount(LoginScreen, {
+				target: document.body,
+				props: { controller: idleController },
+			});
+			await tick();
+
+			const link = document.querySelector("a.verification-link");
+			expect(link).toBeNull();
+		});
 	});
 });


### PR DESCRIPTION
## 概要\nDevice Flow ログイン時の verification_uri リンクを改善。`window.open` から `controller.openVerificationUri` (`chrome.tabs.create`) に変更し、polling フェーズでもリンクを表示し続けるようにした。URI 検証を `https://github.com/` プレフィックスに強化し、`rel=\"noopener noreferrer\"` を追加。\n\n## 変更内容\n- `src/shared/usecase/device-flow.controller.ts`: `openVerificationUri(uri: string)` メソッド追加。`ALLOWED_VERIFICATION_URI_PREFIX` 定数で URI 検証後 `chrome.tabs.create` を実行\n- `src/sidepanel/components/LoginScreen.svelte`: `chrome.tabs.create` 直呼び出しを `controller.openVerificationUri()` 経由に変更、`lastVerificationUri` 状態追加で polling フェーズでもリンク表示、`rel=\"noopener noreferrer\"` 追加\n- `src/test/sidepanel/components/LoginScreen.test.ts`: verification link 関連テスト8件追加（表示、クリック、polling 維持、URI 検証、rel 属性、idle 非表示）\n\n## 関連 Issue\n- closes #197\n\n## テスト\n- [x] TypeScript 型チェック通過 (`pnpm check`)\n- [x] フロントエンドテスト通過 (`pnpm test`) — 561 テスト全 PASS\n- [ ] Rust lint 通過 (`cargo clippy --all-targets`) — Rust 変更なし\n- [ ] Rust テスト通過 (`cargo test`) — Rust 変更なし\n- [x] `/verify` で検証ループ PASS\n\n## レビュー観点\n- `DeviceFlowController` に `openVerificationUri` を追加したことで、Svelte コンポーネントから Chrome API 直呼び出しが解消されているか\n- polling フェーズでの `lastVerificationUri` 保持パターンが `lastUserCode` と整合しているか\n- URI 検証の二重防御（controller 側 + Svelte 側）が適切か