### PR TITLE
feat: PR一覧に未解決コメント数を表示する

### DIFF
--- a/rust-core/crates/adapter-wasm/src/dto.rs
+++ b/rust-core/crates/adapter-wasm/src/dto.rs
@@ -28,6 +28,7 @@ pub struct PrItemDto {
     pub updated_at: String,
     /// PR の変更規模ラベル ("XS", "S", "M", "L", "XL")。
     pub size_label: String,
+    pub unresolved_comment_count: u32,
 }
 
 impl From<PullRequest> for PrItemDto {
@@ -47,6 +48,7 @@ impl From<PullRequest> for PrItemDto {
             deletions,
             created_at,
             updated_at,
+            unresolved_comment_count,
         ) = pr.into_parts();
         Self {
             id,
@@ -66,6 +68,7 @@ impl From<PullRequest> for PrItemDto {
             size_label: determine_pr_size(additions, deletions)
                 .as_label()
                 .to_string(),
+            unresolved_comment_count,
         }
     }
 }
@@ -103,6 +106,7 @@ mod tests {
             created_at: "2026-01-01T00:00:00Z".to_string(),
             updated_at: "2026-01-02T00:00:00Z".to_string(),
             size_label: "M".to_string(),
+            unresolved_comment_count: 0,
         }
     }
 
@@ -195,6 +199,7 @@ mod tests {
             80,
             "2026-03-01T12:00:00Z".to_string(),
             "2026-03-15T18:30:00Z".to_string(),
+            0,
         )
         .expect("test PR should be valid");
 
@@ -250,6 +255,7 @@ mod tests {
                 5,
                 "2026-03-20T00:00:00Z".to_string(),
                 "2026-03-21T10:00:00Z".to_string(),
+                0,
             )
             .expect("test PR should be valid");
 
@@ -262,6 +268,79 @@ mod tests {
             assert_eq!(dto.ci_status, ci, "ci mismatch at index {i}");
             assert_eq!(dto.number, n, "number mismatch at index {i}");
         }
+    }
+
+    // --- unresolved_comment_count tests (Issue #200) ---
+
+    #[test]
+    fn from_pull_request_maps_unresolved_comment_count() {
+        use domain::entity::PullRequest;
+
+        let pr = PullRequest::new(
+            "PR_789".to_string(),
+            10,
+            "Fix comments".to_string(),
+            "alice".to_string(),
+            "https://github.com/org/repo/pull/10".to_string(),
+            "org/repo".to_string(),
+            false,
+            ApprovalStatus::Approved,
+            CiStatus::Passed,
+            MergeableStatus::Unknown,
+            50,
+            10,
+            "2026-03-01T00:00:00Z".to_string(),
+            "2026-03-02T00:00:00Z".to_string(),
+            4, // unresolved_comment_count
+        )
+        .expect("valid PR");
+
+        let dto = PrItemDto::from(pr);
+        assert_eq!(
+            dto.unresolved_comment_count, 4,
+            "unresolved_comment_count should be mapped from PullRequest to PrItemDto"
+        );
+    }
+
+    #[test]
+    fn from_pull_request_maps_zero_unresolved_comment_count() {
+        use domain::entity::PullRequest;
+
+        let pr = PullRequest::new(
+            "PR_zero".to_string(),
+            20,
+            "No comments".to_string(),
+            "bob".to_string(),
+            "https://github.com/org/repo/pull/20".to_string(),
+            "org/repo".to_string(),
+            false,
+            ApprovalStatus::Approved,
+            CiStatus::Passed,
+            MergeableStatus::Unknown,
+            30,
+            5,
+            "2026-03-01T00:00:00Z".to_string(),
+            "2026-03-02T00:00:00Z".to_string(),
+            0, // unresolved_comment_count
+        )
+        .expect("valid PR");
+
+        let dto = PrItemDto::from(pr);
+        assert_eq!(
+            dto.unresolved_comment_count, 0,
+            "zero unresolved_comment_count should be preserved through DTO mapping"
+        );
+    }
+
+    #[test]
+    fn pr_item_dto_serde_includes_unresolved_comment_count_camel_case() {
+        let mut item = make_pr_item();
+        item.unresolved_comment_count = 12;
+        let json = serde_json::to_string(&item).expect("serialize should succeed");
+        assert!(
+            json.contains("\"unresolvedCommentCount\":12"),
+            "JSON should contain unresolvedCommentCount in camelCase, got: {json}"
+        );
     }
 
     #[test]

--- a/rust-core/crates/adapter-wasm/src/parser.rs
+++ b/rust-core/crates/adapter-wasm/src/parser.rs
@@ -47,6 +47,21 @@ pub struct PrNode {
     pub created_at: String,
     pub updated_at: String,
     pub mergeable: Option<String>,
+    pub review_threads: Option<ReviewThreadConnection>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ReviewThreadConnection {
+    /// GraphQL の totalCount。nodes が first:100 で切り捨てられたかどうかの判定に使える。
+    pub total_count: Option<u32>,
+    pub nodes: Vec<ReviewThread>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ReviewThread {
+    pub is_resolved: bool,
 }
 
 #[derive(Debug, Deserialize)]
@@ -140,6 +155,14 @@ pub fn convert_node_to_pull_request(node: PrNode) -> Result<PullRequest, WasmErr
     let mergeable_status =
         usecase::determine::determine_mergeable_status(node.mergeable.as_deref())?;
 
+    let unresolved_comment_count = node
+        .review_threads
+        .map(|rt| {
+            let count = rt.nodes.iter().filter(|t| !t.is_resolved).count();
+            u32::try_from(count).unwrap_or(u32::MAX)
+        })
+        .unwrap_or(0);
+
     let pr = PullRequest::new(
         node.id,
         node.number,
@@ -155,6 +178,7 @@ pub fn convert_node_to_pull_request(node: PrNode) -> Result<PullRequest, WasmErr
         node.deletions.unwrap_or(0),
         node.created_at,
         node.updated_at,
+        unresolved_comment_count,
     )?;
 
     Ok(pr)
@@ -823,6 +847,214 @@ mod tests {
         assert!(parsed.my_prs.is_empty());
         assert_eq!(parsed.review_requests.len(), 1);
         assert_eq!(parsed.review_requests[0].id(), "PR_1");
+    }
+
+    // --- unresolved_comment_count tests (Issue #200) ---
+
+    #[test]
+    fn review_threads_with_unresolved_comments_are_counted() {
+        let json = r#"{
+            "data": {
+                "myPrs": {
+                    "edges": [
+                        {
+                            "node": {
+                                "id": "PR_1",
+                                "title": "test pr",
+                                "url": "https://github.com/o/r/pull/1",
+                                "number": 1,
+                                "isDraft": false,
+                                "reviewDecision": "APPROVED",
+                                "author": { "login": "alice" },
+                                "commits": { "nodes": [] },
+                                "repository": { "nameWithOwner": "o/r" },
+                                "additions": 10,
+                                "deletions": 5,
+                                "createdAt": "2026-01-01T00:00:00Z",
+                                "updatedAt": "2026-01-02T00:00:00Z",
+                                "mergeable": null,
+                                "reviewThreads": {
+                                    "nodes": [
+                                        { "isResolved": false },
+                                        { "isResolved": true },
+                                        { "isResolved": false },
+                                        { "isResolved": false }
+                                    ]
+                                }
+                            }
+                        }
+                    ]
+                },
+                "reviewRequested": { "edges": [] }
+            }
+        }"#;
+
+        let parsed = parse_pull_request_nodes(json).expect("should parse");
+        assert_eq!(
+            parsed.my_prs[0].unresolved_comment_count(),
+            3,
+            "3 of 4 review threads are unresolved"
+        );
+    }
+
+    #[test]
+    fn review_threads_null_defaults_to_zero_unresolved() {
+        let json = r#"{
+            "data": {
+                "myPrs": {
+                    "edges": [
+                        {
+                            "node": {
+                                "id": "PR_1",
+                                "title": "test pr",
+                                "url": "https://github.com/o/r/pull/1",
+                                "number": 1,
+                                "isDraft": false,
+                                "reviewDecision": null,
+                                "author": { "login": "alice" },
+                                "commits": { "nodes": [] },
+                                "repository": { "nameWithOwner": "o/r" },
+                                "createdAt": "2026-01-01T00:00:00Z",
+                                "updatedAt": "2026-01-02T00:00:00Z",
+                                "mergeable": null,
+                                "reviewThreads": null
+                            }
+                        }
+                    ]
+                },
+                "reviewRequested": { "edges": [] }
+            }
+        }"#;
+
+        let parsed = parse_pull_request_nodes(json).expect("should parse");
+        assert_eq!(
+            parsed.my_prs[0].unresolved_comment_count(),
+            0,
+            "null reviewThreads should default to 0"
+        );
+    }
+
+    #[test]
+    fn review_threads_absent_defaults_to_zero_unresolved() {
+        // reviewThreads フィールドが JSON に存在しないケース
+        let json = r#"{
+            "data": {
+                "myPrs": {
+                    "edges": [
+                        {
+                            "node": {
+                                "id": "PR_1",
+                                "title": "test pr",
+                                "url": "https://github.com/o/r/pull/1",
+                                "number": 1,
+                                "isDraft": false,
+                                "reviewDecision": null,
+                                "author": { "login": "alice" },
+                                "commits": { "nodes": [] },
+                                "repository": { "nameWithOwner": "o/r" },
+                                "createdAt": "2026-01-01T00:00:00Z",
+                                "updatedAt": "2026-01-02T00:00:00Z",
+                                "mergeable": null
+                            }
+                        }
+                    ]
+                },
+                "reviewRequested": { "edges": [] }
+            }
+        }"#;
+
+        let parsed = parse_pull_request_nodes(json).expect("should parse");
+        assert_eq!(
+            parsed.my_prs[0].unresolved_comment_count(),
+            0,
+            "absent reviewThreads should default to 0"
+        );
+    }
+
+    #[test]
+    fn review_threads_empty_nodes_gives_zero_unresolved() {
+        let json = r#"{
+            "data": {
+                "myPrs": {
+                    "edges": [
+                        {
+                            "node": {
+                                "id": "PR_1",
+                                "title": "test pr",
+                                "url": "https://github.com/o/r/pull/1",
+                                "number": 1,
+                                "isDraft": false,
+                                "reviewDecision": "APPROVED",
+                                "author": { "login": "alice" },
+                                "commits": { "nodes": [] },
+                                "repository": { "nameWithOwner": "o/r" },
+                                "additions": 10,
+                                "deletions": 5,
+                                "createdAt": "2026-01-01T00:00:00Z",
+                                "updatedAt": "2026-01-02T00:00:00Z",
+                                "mergeable": null,
+                                "reviewThreads": {
+                                    "nodes": []
+                                }
+                            }
+                        }
+                    ]
+                },
+                "reviewRequested": { "edges": [] }
+            }
+        }"#;
+
+        let parsed = parse_pull_request_nodes(json).expect("should parse");
+        assert_eq!(
+            parsed.my_prs[0].unresolved_comment_count(),
+            0,
+            "empty reviewThreads.nodes should give 0 unresolved"
+        );
+    }
+
+    #[test]
+    fn review_threads_all_resolved_gives_zero_unresolved() {
+        let json = r#"{
+            "data": {
+                "myPrs": {
+                    "edges": [
+                        {
+                            "node": {
+                                "id": "PR_1",
+                                "title": "test pr",
+                                "url": "https://github.com/o/r/pull/1",
+                                "number": 1,
+                                "isDraft": false,
+                                "reviewDecision": "APPROVED",
+                                "author": { "login": "alice" },
+                                "commits": { "nodes": [] },
+                                "repository": { "nameWithOwner": "o/r" },
+                                "additions": 10,
+                                "deletions": 5,
+                                "createdAt": "2026-01-01T00:00:00Z",
+                                "updatedAt": "2026-01-02T00:00:00Z",
+                                "mergeable": null,
+                                "reviewThreads": {
+                                    "nodes": [
+                                        { "isResolved": true },
+                                        { "isResolved": true },
+                                        { "isResolved": true }
+                                    ]
+                                }
+                            }
+                        }
+                    ]
+                },
+                "reviewRequested": { "edges": [] }
+            }
+        }"#;
+
+        let parsed = parse_pull_request_nodes(json).expect("should parse");
+        assert_eq!(
+            parsed.my_prs[0].unresolved_comment_count(),
+            0,
+            "all resolved threads should give 0 unresolved"
+        );
     }
 
     #[test]

--- a/rust-core/crates/domain/src/entity.rs
+++ b/rust-core/crates/domain/src/entity.rs
@@ -24,6 +24,7 @@ pub struct PullRequest {
     /// ISO 8601 形式の文字列 (例: "2026-01-02T00:00:00Z")。
     /// `created_at` と同じ理由で String を採用。
     updated_at: String,
+    unresolved_comment_count: u32,
 }
 
 impl PullRequest {
@@ -43,6 +44,7 @@ impl PullRequest {
         deletions: u32,
         created_at: String,
         updated_at: String,
+        unresolved_comment_count: u32,
     ) -> Result<Self, crate::error::DomainError> {
         use crate::error::DomainError;
 
@@ -117,6 +119,7 @@ impl PullRequest {
             deletions,
             created_at,
             updated_at,
+            unresolved_comment_count,
         })
     }
 
@@ -176,6 +179,10 @@ impl PullRequest {
         &self.updated_at
     }
 
+    pub fn unresolved_comment_count(&self) -> u32 {
+        self.unresolved_comment_count
+    }
+
     /// PullRequest を分解してフィールドの所有権を返す。
     /// adapter 層で不要なアロケーションを避けるために使用する。
     #[allow(clippy::type_complexity)]
@@ -196,6 +203,7 @@ impl PullRequest {
         u32,
         String,
         String,
+        u32,
     ) {
         (
             self.id,
@@ -212,6 +220,7 @@ impl PullRequest {
             self.deletions,
             self.created_at,
             self.updated_at,
+            self.unresolved_comment_count,
         )
     }
 }
@@ -240,6 +249,7 @@ mod tests {
             20,
             "2026-01-01T00:00:00Z".to_string(),
             "2026-01-02T00:00:00Z".to_string(),
+            0,
         )
         .expect("make_valid_pr: all fields are valid")
     }
@@ -308,6 +318,7 @@ mod tests {
             20,
             "2026-01-01T00:00:00Z".to_string(),
             "2026-01-02T00:00:00Z".to_string(),
+            0,
         );
         assert!(result.is_ok());
     }
@@ -329,6 +340,7 @@ mod tests {
             0,
             "2026-01-01T00:00:00Z".to_string(),
             "2026-01-02T00:00:00Z".to_string(),
+            0,
         );
         assert!(result.is_err());
         assert!(matches!(
@@ -354,6 +366,7 @@ mod tests {
             0,
             "2026-01-01T00:00:00Z".to_string(),
             "2026-01-02T00:00:00Z".to_string(),
+            0,
         );
         assert!(result.is_err());
         assert!(matches!(
@@ -379,6 +392,7 @@ mod tests {
             0,
             "2026-01-01T00:00:00Z".to_string(),
             "2026-01-02T00:00:00Z".to_string(),
+            0,
         );
         assert!(result.is_err());
         assert!(matches!(
@@ -404,6 +418,7 @@ mod tests {
             0,
             "2026-01-01T00:00:00Z".to_string(),
             "2026-01-02T00:00:00Z".to_string(),
+            0,
         );
         assert!(result.is_err());
         assert!(matches!(
@@ -429,6 +444,7 @@ mod tests {
             0,
             "2026-01-01T00:00:00Z".to_string(),
             "2026-01-02T00:00:00Z".to_string(),
+            0,
         );
         assert!(result.is_err());
         assert!(matches!(
@@ -454,6 +470,7 @@ mod tests {
             0,
             "".to_string(),
             "2026-01-02T00:00:00Z".to_string(),
+            0,
         );
         assert!(result.is_err());
         assert!(matches!(
@@ -479,6 +496,7 @@ mod tests {
             0,
             "2026-01-01T00:00:00Z".to_string(),
             "".to_string(),
+            0,
         );
         assert!(result.is_err());
         assert!(matches!(
@@ -504,6 +522,7 @@ mod tests {
             0,
             "2026-01-01T00:00:00Z".to_string(),
             "2026-01-02T00:00:00Z".to_string(),
+            0,
         );
         assert!(result.is_err());
         assert!(matches!(
@@ -529,6 +548,7 @@ mod tests {
             0,
             "2026-01-01T00:00:00Z".to_string(),
             "2026-01-02T00:00:00Z".to_string(),
+            0,
         );
         assert!(result.is_err());
         assert!(matches!(
@@ -554,6 +574,7 @@ mod tests {
             0,
             "2026-01-01T00:00:00Z".to_string(),
             "2026-01-02T00:00:00Z".to_string(),
+            0,
         );
         assert!(matches!(
             result.unwrap_err(),
@@ -578,6 +599,7 @@ mod tests {
             0,
             "2026-01-01T00:00:00Z".to_string(),
             "2026-01-02T00:00:00Z".to_string(),
+            0,
         );
         assert!(matches!(
             result.unwrap_err(),
@@ -602,6 +624,7 @@ mod tests {
             0,
             "2026-01-01T00:00:00Z".to_string(),
             "2026-01-02T00:00:00Z".to_string(),
+            0,
         );
         assert!(result.is_ok());
     }
@@ -623,5 +646,79 @@ mod tests {
         assert_eq!(pr.deletions(), 20);
         assert_eq!(pr.created_at(), "2026-01-01T00:00:00Z");
         assert_eq!(pr.updated_at(), "2026-01-02T00:00:00Z");
+    }
+
+    // --- unresolved_comment_count tests (Issue #200) ---
+
+    #[test]
+    fn new_accepts_unresolved_comment_count_parameter() {
+        let result = PullRequest::new(
+            "PR_123".to_string(),
+            42,
+            "Add feature X".to_string(),
+            "octocat".to_string(),
+            "https://github.com/owner/repo/pull/42".to_string(),
+            "owner/repo".to_string(),
+            false,
+            ApprovalStatus::Approved,
+            CiStatus::Passed,
+            MergeableStatus::Unknown,
+            100,
+            20,
+            "2026-01-01T00:00:00Z".to_string(),
+            "2026-01-02T00:00:00Z".to_string(),
+            3, // unresolved_comment_count
+        );
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn unresolved_comment_count_getter_returns_correct_value() {
+        let pr = PullRequest::new(
+            "PR_123".to_string(),
+            42,
+            "Add feature X".to_string(),
+            "octocat".to_string(),
+            "https://github.com/owner/repo/pull/42".to_string(),
+            "owner/repo".to_string(),
+            false,
+            ApprovalStatus::Approved,
+            CiStatus::Passed,
+            MergeableStatus::Unknown,
+            100,
+            20,
+            "2026-01-01T00:00:00Z".to_string(),
+            "2026-01-02T00:00:00Z".to_string(),
+            5, // unresolved_comment_count
+        )
+        .expect("valid PR");
+        assert_eq!(pr.unresolved_comment_count(), 5);
+    }
+
+    #[test]
+    fn serde_includes_unresolved_comment_count_key() {
+        let pr = PullRequest::new(
+            "PR_123".to_string(),
+            42,
+            "Add feature X".to_string(),
+            "octocat".to_string(),
+            "https://github.com/owner/repo/pull/42".to_string(),
+            "owner/repo".to_string(),
+            false,
+            ApprovalStatus::Approved,
+            CiStatus::Passed,
+            MergeableStatus::Unknown,
+            100,
+            20,
+            "2026-01-01T00:00:00Z".to_string(),
+            "2026-01-02T00:00:00Z".to_string(),
+            7, // unresolved_comment_count
+        )
+        .expect("valid PR");
+        let json = serde_json::to_string(&pr).expect("serialize should succeed");
+        assert!(
+            json.contains("\"unresolvedCommentCount\":7"),
+            "JSON should contain unresolvedCommentCount field, got: {json}"
+        );
     }
 }

--- a/rust-core/crates/usecase/src/process.rs
+++ b/rust-core/crates/usecase/src/process.rs
@@ -42,6 +42,7 @@ mod tests {
             5,
             "2026-01-01T00:00:00Z".to_string(),
             updated_at.to_string(),
+            0,
         )
         .expect("test PR should be valid")
     }

--- a/rust-core/crates/usecase/src/sort.rs
+++ b/rust-core/crates/usecase/src/sort.rs
@@ -25,6 +25,7 @@ mod tests {
             5,
             "2026-01-01T00:00:00Z".to_string(),
             updated_at.to_string(),
+            0,
         )
         .expect("test PR should be valid")
     }

--- a/src/adapter/github/graphql-client.ts
+++ b/src/adapter/github/graphql-client.ts
@@ -56,6 +56,12 @@ fragment PrFields on PullRequest {
   createdAt
   updatedAt
   mergeable
+  reviewThreads(first: 100) {
+    totalCount
+    nodes {
+      isResolved
+    }
+  }
 }`;
 
 const PULL_REQUESTS_QUERY = `

--- a/src/domain/ports/pr-processor.port.ts
+++ b/src/domain/ports/pr-processor.port.ts
@@ -19,6 +19,7 @@ export interface PrItemDto {
 	readonly createdAt: string;
 	readonly updatedAt: string;
 	readonly sizeLabel: string;
+	readonly unresolvedCommentCount: number;
 }
 
 /** Rust の domain::dto::PrListDto に対応する TypeScript 型 */

--- a/src/sidepanel/components/PrItem.svelte
+++ b/src/sidepanel/components/PrItem.svelte
@@ -5,6 +5,7 @@
 	import CiBadge from "./CiBadge.svelte";
 	import MergeableBadge from "./MergeableBadge.svelte";
 	import DraftBadge from "./DraftBadge.svelte";
+	import UnresolvedCommentBadge from "./UnresolvedCommentBadge.svelte";
 	import RelativeTime from "./RelativeTime.svelte";
 	import SizeBadge from "./SizeBadge.svelte";
 
@@ -45,6 +46,7 @@
 			<ApprovalBadge approvalStatus={pr.approvalStatus} />
 			<CiBadge ciStatus={pr.ciStatus} />
 			<MergeableBadge mergeableStatus={pr.mergeableStatus} />
+			<UnresolvedCommentBadge count={pr.unresolvedCommentCount} />
 		{/if}
 	</div>
 </div>

--- a/src/sidepanel/components/UnresolvedCommentBadge.svelte
+++ b/src/sidepanel/components/UnresolvedCommentBadge.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+	import "../styles/badge.css";
+
+	type Props = {
+		count: number;
+	};
+
+	const { count }: Props = $props();
+</script>
+
+{#if count > 0}
+	<span class="badge badge-orange" title="Unresolved comments">💬 {count}</span>
+{/if}

--- a/src/test/shared/usecase/auto-refresh.usecase.test.ts
+++ b/src/test/shared/usecase/auto-refresh.usecase.test.ts
@@ -40,6 +40,7 @@ describe("auto-refresh usecase", () => {
 					createdAt: "2026-03-20T00:00:00Z",
 					updatedAt: "2026-03-21T00:00:00Z",
 					sizeLabel: "S",
+					unresolvedCommentCount: 0,
 				},
 			],
 			totalCount: 1,

--- a/src/test/shared/usecase/pr.usecase.test.ts
+++ b/src/test/shared/usecase/pr.usecase.test.ts
@@ -31,6 +31,7 @@ describe("pr usecase", () => {
 					createdAt: "2026-03-20T00:00:00Z",
 					updatedAt: "2026-03-21T00:00:00Z",
 					sizeLabel: "S",
+					unresolvedCommentCount: 0,
 				},
 			],
 			totalCount: 1,

--- a/src/test/sidepanel/components/PrItem.test.ts
+++ b/src/test/sidepanel/components/PrItem.test.ts
@@ -20,6 +20,7 @@ function createPrItemDto(overrides: Partial<PrItemDto> = {}): PrItemDto {
 		createdAt: "2026-03-20T10:00:00Z",
 		updatedAt: "2026-03-23T10:00:00Z",
 		sizeLabel: "S",
+		unresolvedCommentCount: 0,
 		...overrides,
 	};
 }

--- a/src/test/sidepanel/components/UnresolvedCommentBadge.test.ts
+++ b/src/test/sidepanel/components/UnresolvedCommentBadge.test.ts
@@ -1,0 +1,54 @@
+import { mount, unmount } from "svelte";
+import { afterEach, describe, expect, it } from "vitest";
+import UnresolvedCommentBadge from "../../../sidepanel/components/UnresolvedCommentBadge.svelte";
+
+describe("UnresolvedCommentBadge", () => {
+	let component: ReturnType<typeof mount>;
+
+	afterEach(() => {
+		if (component) {
+			unmount(component);
+		}
+		document.body.innerHTML = "";
+	});
+
+	it("should render nothing when count is 0", () => {
+		component = mount(UnresolvedCommentBadge, {
+			target: document.body,
+			props: { count: 0 },
+		});
+		const badge = document.querySelector(".badge");
+		expect(badge).toBeNull();
+	});
+
+	it("should render badge with count when count is 1", () => {
+		component = mount(UnresolvedCommentBadge, {
+			target: document.body,
+			props: { count: 1 },
+		});
+		const badge = document.querySelector(".badge");
+		expect(badge).not.toBeNull();
+		expect(badge?.textContent?.trim()).toContain("1");
+	});
+
+	it("should render badge with count when count is 99", () => {
+		component = mount(UnresolvedCommentBadge, {
+			target: document.body,
+			props: { count: 99 },
+		});
+		const badge = document.querySelector(".badge");
+		expect(badge).not.toBeNull();
+		expect(badge?.textContent?.trim()).toContain("99");
+	});
+
+	it("should include a comment icon", () => {
+		component = mount(UnresolvedCommentBadge, {
+			target: document.body,
+			props: { count: 3 },
+		});
+		const badge = document.querySelector(".badge");
+		expect(badge).not.toBeNull();
+		// コメントアイコン (💬 or SVG) が存在することを確認
+		expect(badge?.textContent?.trim()).toMatch(/💬\s*3|3\s*💬/);
+	});
+});

--- a/src/wasm/pr-processor.test.ts
+++ b/src/wasm/pr-processor.test.ts
@@ -54,6 +54,7 @@ describe("PrProcessorPort", () => {
 			createdAt: "2026-03-20T00:00:00Z",
 			updatedAt: "2026-03-21T00:00:00Z",
 			sizeLabel: "S",
+			unresolvedCommentCount: 0,
 		};
 
 		expect(item.sizeLabel).toBe("S");


### PR DESCRIPTION
## 概要\nPR一覧の各行に未解決（unresolved）のレビューコメント数を表示する機能を追加。GraphQL API から `reviewThreads` を取得し、Rust/WASM で未解決スレッド数をカウントして DTO に含め、Svelte バッジコンポーネントで表示する。0件の場合は非表示。\n\n## 変更内容\n- `src/adapter/github/graphql-client.ts`: `PR_FIELDS_FRAGMENT` に `reviewThreads(first: 100) { totalCount nodes { isResolved } }` を追加\n- `rust-core/crates/domain/src/entity.rs`: `PullRequest` に `unresolved_comment_count: u32` フィールド・getter・`into_parts()` 拡張を追加\n- `rust-core/crates/adapter-wasm/src/parser.rs`: `ReviewThreadConnection` / `ReviewThread` struct 追加、`convert_node_to_pull_request` で未解決スレッド数カウントロジック追加（防御的キャスト `u32::try_from`）\n- `rust-core/crates/adapter-wasm/src/dto.rs`: `PrItemDto` に `unresolved_comment_count` フィールド追加、`From<PullRequest>` impl 更新\n- `rust-core/crates/usecase/src/process.rs`, `sort.rs`: テストヘルパーに引数追加\n- `src/domain/ports/pr-processor.port.ts`: `PrItemDto` interface に `unresolvedCommentCount` 追加\n- `src/sidepanel/components/UnresolvedCommentBadge.svelte`: 新規バッジコンポーネント（count > 0 で 💬+数字表示）\n- `src/sidepanel/components/PrItem.svelte`: `UnresolvedCommentBadge` を組み込み\n- テストファイル群: 各層でテスト追加・既存テストの引数更新\n\n## 関連 Issue\n- closes #200\n\n## テスト\n- [x] TypeScript 型チェック通過 (`pnpm check`)\n- [x] フロントエンドテスト通過 (`pnpm test`) — 557 tests\n- [x] Rust lint 通過 (`cargo clippy --all-targets`)\n- [x] Rust テスト通過 (`cargo test`) — 138 tests\n- [x] `/verify` で検証ループ PASS\n\n## レビュー観点\n- `reviewThreads(first: 100)` の上限: `totalCount` を取得して将来的に切り捨て検知可能にしたが、現時点では100件超時の UI 表示は未実装（100件超は極めてレア）\n- `as u32` → `u32::try_from(count).unwrap_or(u32::MAX)` の防御的キャスト\n- Draft PR では既存バッジと同様に `UnresolvedCommentBadge` も非表示（`{#if !pr.isDraft}` ブロック内）