### PR TITLE
feat: PR選択時に既存タブがあればそのタブをアクティブにする

### DIFF
--- a/manifest.config.ts
+++ b/manifest.config.ts
@@ -5,7 +5,7 @@ export default defineManifest({
 	name: "PR Sidebar",
 	version: "0.0.1",
 	description: "GitHub PR Dashboard in Chrome Side Panel",
-	permissions: ["sidePanel", "storage", "alarms"],
+	permissions: ["sidePanel", "storage", "alarms", "tabs"],
 	host_permissions: ["https://github.com/*", "https://api.github.com/*"],
 	content_security_policy: {
 		extension_pages: "script-src 'self' 'wasm-unsafe-eval'; object-src 'self'",

--- a/src/adapter/chrome/tab-navigation.adapter.ts
+++ b/src/adapter/chrome/tab-navigation.adapter.ts
@@ -1,4 +1,5 @@
 import type { TabNavigationPort } from "../../domain/ports/tab-navigation.port";
+import { extractPrBaseUrl } from "../../shared/utils/github-url";
 
 export class TabNavigationAdapter implements TabNavigationPort {
 	async navigateCurrentTab(url: string): Promise<void> {
@@ -14,5 +15,28 @@ export class TabNavigationAdapter implements TabNavigationPort {
 		const tabs = await chrome.tabs.query({ active: true, currentWindow: true });
 		const activeTab = tabs[0];
 		return activeTab?.url ?? null;
+	}
+
+	async findExistingPrTab(prBaseUrl: string): Promise<number | null> {
+		const tabs = await chrome.tabs.query({ url: "https://github.com/*/*/pull/*" });
+		for (const tab of tabs) {
+			if (!tab.url) continue;
+			const baseUrl = extractPrBaseUrl(tab.url);
+			if (baseUrl === prBaseUrl) {
+				return tab.id ?? null;
+			}
+		}
+		return null;
+	}
+
+	async activateTab(tabId: number): Promise<void> {
+		const tab = await chrome.tabs.update(tabId, { active: true });
+		if (tab?.windowId) {
+			await chrome.windows.update(tab.windowId, { focused: true });
+		}
+	}
+
+	async openNewTab(url: string): Promise<void> {
+		await chrome.tabs.create({ url });
 	}
 }

--- a/src/background/message-handler.ts
+++ b/src/background/message-handler.ts
@@ -106,7 +106,31 @@ async function handleMessage(
 			}
 			case "NAVIGATE_TO_PR": {
 				const msg = message as RequestMessage<"NAVIGATE_TO_PR">;
-				await services.tabNavigation.navigateCurrentTab(msg.payload.url);
+				const { url } = msg.payload;
+				if (typeof url !== "string" || !url.startsWith("https://github.com/")) {
+					sendResponse({
+						ok: false,
+						error: { code: "NAVIGATE_TO_PR_ERROR", message: "Invalid URL" },
+					});
+					break;
+				}
+				const prBaseUrl = extractPrBaseUrl(url);
+
+				if (prBaseUrl) {
+					const existingTabId = await services.tabNavigation.findExistingPrTab(prBaseUrl);
+					if (existingTabId !== null) {
+						try {
+							await services.tabNavigation.activateTab(existingTabId);
+						} catch {
+							await services.tabNavigation.openNewTab(url);
+						}
+					} else {
+						await services.tabNavigation.openNewTab(url);
+					}
+				} else {
+					await services.tabNavigation.openNewTab(url);
+				}
+
 				sendResponse({ ok: true, data: undefined });
 				break;
 			}

--- a/src/domain/ports/tab-navigation.port.ts
+++ b/src/domain/ports/tab-navigation.port.ts
@@ -5,4 +5,7 @@
 export interface TabNavigationPort {
 	navigateCurrentTab(url: string): Promise<void>;
 	getCurrentTabUrl(): Promise<string | null>;
+	findExistingPrTab(prBaseUrl: string): Promise<number | null>;
+	activateTab(tabId: number): Promise<void>;
+	openNewTab(url: string): Promise<void>;
 }

--- a/src/test/adapter/chrome/tab-navigation.adapter.test.ts
+++ b/src/test/adapter/chrome/tab-navigation.adapter.test.ts
@@ -58,6 +58,110 @@ describe("TabNavigationAdapter", () => {
 		});
 	});
 
+	describe("findExistingPrTab", () => {
+		it("should return tab id when a tab with the same PR base URL exists", async () => {
+			const mock = getChromeMock();
+			mock.tabs.query.mockResolvedValue([
+				{ id: 10, url: "https://github.com/owner/repo/pull/42" },
+				{ id: 20, url: "https://github.com/other/repo/pull/1" },
+			]);
+
+			const tabId = await adapter.findExistingPrTab("https://github.com/owner/repo/pull/42");
+
+			expect(tabId).toBe(10);
+			expect(mock.tabs.query).toHaveBeenCalledWith({ url: "https://github.com/*/*/pull/*" });
+		});
+
+		it("should match a tab with a sub-path like /files", async () => {
+			const mock = getChromeMock();
+			mock.tabs.query.mockResolvedValue([
+				{ id: 15, url: "https://github.com/owner/repo/pull/42/files#diff-abc" },
+			]);
+
+			const tabId = await adapter.findExistingPrTab("https://github.com/owner/repo/pull/42");
+
+			expect(tabId).toBe(15);
+		});
+
+		it("should return null when no matching PR tab exists", async () => {
+			const mock = getChromeMock();
+			mock.tabs.query.mockResolvedValue([{ id: 10, url: "https://github.com/owner/repo/pull/99" }]);
+
+			const tabId = await adapter.findExistingPrTab("https://github.com/owner/repo/pull/42");
+
+			expect(tabId).toBeNull();
+		});
+
+		it("should ignore tabs for a different PR number", async () => {
+			const mock = getChromeMock();
+			mock.tabs.query.mockResolvedValue([
+				{ id: 10, url: "https://github.com/owner/repo/pull/1" },
+				{ id: 20, url: "https://github.com/owner/repo/pull/2" },
+			]);
+
+			const tabId = await adapter.findExistingPrTab("https://github.com/owner/repo/pull/42");
+
+			expect(tabId).toBeNull();
+		});
+
+		it("should not match pull/42 when searching for pull/4 (no partial number match)", async () => {
+			const mock = getChromeMock();
+			mock.tabs.query.mockResolvedValue([{ id: 10, url: "https://github.com/owner/repo/pull/42" }]);
+
+			const tabId = await adapter.findExistingPrTab("https://github.com/owner/repo/pull/4");
+
+			expect(tabId).toBeNull();
+		});
+
+		it("should skip tabs without a url property", async () => {
+			const mock = getChromeMock();
+			mock.tabs.query.mockResolvedValue([
+				{ id: 5 },
+				{ id: 10, url: "https://github.com/owner/repo/pull/42" },
+			]);
+
+			const tabId = await adapter.findExistingPrTab("https://github.com/owner/repo/pull/42");
+
+			expect(tabId).toBe(10);
+		});
+	});
+
+	describe("activateTab", () => {
+		it("should call chrome.tabs.update and chrome.windows.update to focus the tab", async () => {
+			const mock = getChromeMock();
+			mock.tabs.update.mockResolvedValue({ id: 10, windowId: 5 });
+			mock.windows.update.mockResolvedValue(undefined);
+
+			await adapter.activateTab(10);
+
+			expect(mock.tabs.update).toHaveBeenCalledWith(10, { active: true });
+			expect(mock.windows.update).toHaveBeenCalledWith(5, { focused: true });
+		});
+
+		it("should not call chrome.windows.update when tab has no windowId", async () => {
+			const mock = getChromeMock();
+			mock.tabs.update.mockResolvedValue({ id: 10 });
+
+			await adapter.activateTab(10);
+
+			expect(mock.tabs.update).toHaveBeenCalledWith(10, { active: true });
+			expect(mock.windows.update).not.toHaveBeenCalled();
+		});
+	});
+
+	describe("openNewTab", () => {
+		it("should call chrome.tabs.create with the url", async () => {
+			const mock = getChromeMock();
+			mock.tabs.create.mockResolvedValue({ id: 99 });
+
+			await adapter.openNewTab("https://github.com/owner/repo/pull/42");
+
+			expect(mock.tabs.create).toHaveBeenCalledWith({
+				url: "https://github.com/owner/repo/pull/42",
+			});
+		});
+	});
+
 	describe("getCurrentTabUrl", () => {
 		it("should return the URL of the active tab", async () => {
 			const mock = getChromeMock();

--- a/src/test/background/message-handler-pr.test.ts
+++ b/src/test/background/message-handler-pr.test.ts
@@ -69,7 +69,13 @@ describe("message-handler FETCH_PRS", () => {
 			githubApi: mockGitHubApi,
 			prProcessor: mockPrProcessor,
 			badge: mockBadge,
-			tabNavigation: { navigateCurrentTab: vi.fn(), getCurrentTabUrl: vi.fn() },
+			tabNavigation: {
+				navigateCurrentTab: vi.fn(),
+				getCurrentTabUrl: vi.fn(),
+				findExistingPrTab: vi.fn().mockResolvedValue(null),
+				activateTab: vi.fn().mockResolvedValue(undefined),
+				openNewTab: vi.fn().mockResolvedValue(undefined),
+			},
 		});
 	});
 

--- a/src/test/background/message-handler.test.ts
+++ b/src/test/background/message-handler.test.ts
@@ -361,10 +361,22 @@ describe("createMessageHandler", () => {
 	});
 
 	describe("NAVIGATE_TO_PR", () => {
-		let mockTabNavigation: { navigateCurrentTab: ReturnType<typeof vi.fn> };
+		let mockTabNavigation: {
+			navigateCurrentTab: ReturnType<typeof vi.fn>;
+			findExistingPrTab: ReturnType<typeof vi.fn>;
+			activateTab: ReturnType<typeof vi.fn>;
+			openNewTab: ReturnType<typeof vi.fn>;
+			getCurrentTabUrl: ReturnType<typeof vi.fn>;
+		};
 
 		beforeEach(() => {
-			mockTabNavigation = { navigateCurrentTab: vi.fn().mockResolvedValue(undefined) };
+			mockTabNavigation = {
+				navigateCurrentTab: vi.fn().mockResolvedValue(undefined),
+				findExistingPrTab: vi.fn().mockResolvedValue(null),
+				activateTab: vi.fn().mockResolvedValue(undefined),
+				openNewTab: vi.fn().mockResolvedValue(undefined),
+				getCurrentTabUrl: vi.fn().mockResolvedValue(null),
+			};
 			services = {
 				auth: mockAuth,
 				tabNavigation: mockTabNavigation,
@@ -372,8 +384,7 @@ describe("createMessageHandler", () => {
 			handler = createMessageHandler(services);
 		});
 
-		// NOTE: RED フェーズでは MESSAGE_TYPES に NAVIGATE_TO_PR がないため isRequestMessage で弾かれタイムアウトで失敗する
-		it("should call tabNavigation.navigateCurrentTab with the url", async () => {
+		it("should open new tab via tab reuse flow for PR URL", async () => {
 			const sendResponse = vi.fn();
 
 			handler(
@@ -386,14 +397,16 @@ describe("createMessageHandler", () => {
 				expect(sendResponse).toHaveBeenCalled();
 			});
 
-			expect(mockTabNavigation.navigateCurrentTab).toHaveBeenCalledWith(
+			expect(mockTabNavigation.findExistingPrTab).toHaveBeenCalledWith(
+				"https://github.com/owner/repo/pull/42",
+			);
+			expect(mockTabNavigation.openNewTab).toHaveBeenCalledWith(
 				"https://github.com/owner/repo/pull/42",
 			);
 			const response = sendResponse.mock.calls[0][0];
 			expect(response).toEqual({ ok: true, data: undefined });
 		});
 
-		// NOTE: RED フェーズでは MESSAGE_TYPES に NAVIGATE_TO_PR がないため isRequestMessage で弾かれタイムアウトで失敗する
 		it("should respond with success when navigation succeeds", async () => {
 			const sendResponse = vi.fn();
 
@@ -411,9 +424,8 @@ describe("createMessageHandler", () => {
 			expect(response.ok).toBe(true);
 		});
 
-		// NOTE: RED フェーズでは MESSAGE_TYPES に NAVIGATE_TO_PR がないため isRequestMessage で弾かれタイムアウトで失敗する
-		it("should respond with error when navigateCurrentTab throws", async () => {
-			mockTabNavigation.navigateCurrentTab.mockRejectedValue(new Error("No active tab"));
+		it("should respond with error when openNewTab throws", async () => {
+			mockTabNavigation.openNewTab.mockRejectedValue(new Error("Tab creation failed"));
 			const sendResponse = vi.fn();
 
 			handler(
@@ -431,7 +443,6 @@ describe("createMessageHandler", () => {
 			expect(response.error.code).toBe("NAVIGATE_TO_PR_ERROR");
 		});
 
-		// NOTE: RED フェーズでは MESSAGE_TYPES に NAVIGATE_TO_PR がないため isRequestMessage で弾かれタイムアウトで失敗する
 		it("should respond with error when payload is missing", async () => {
 			const sendResponse = vi.fn();
 
@@ -443,6 +454,133 @@ describe("createMessageHandler", () => {
 
 			const response = sendResponse.mock.calls[0][0];
 			expect(response.ok).toBe(false);
+		});
+
+		it("should respond with error when url does not start with https://github.com/", async () => {
+			const sendResponse = vi.fn();
+			handler(
+				{ type: "NAVIGATE_TO_PR", payload: { url: "javascript:alert(1)" } },
+				createTrustedSender(),
+				sendResponse,
+			);
+			await vi.waitFor(() => {
+				expect(sendResponse).toHaveBeenCalled();
+			});
+			const response = sendResponse.mock.calls[0][0];
+			expect(response.ok).toBe(false);
+			expect(response.error.code).toBe("NAVIGATE_TO_PR_ERROR");
+		});
+	});
+
+	describe("NAVIGATE_TO_PR (tab reuse)", () => {
+		let mockTabNavigation: {
+			navigateCurrentTab: ReturnType<typeof vi.fn>;
+			findExistingPrTab: ReturnType<typeof vi.fn>;
+			activateTab: ReturnType<typeof vi.fn>;
+			openNewTab: ReturnType<typeof vi.fn>;
+			getCurrentTabUrl: ReturnType<typeof vi.fn>;
+		};
+
+		beforeEach(() => {
+			mockTabNavigation = {
+				navigateCurrentTab: vi.fn().mockResolvedValue(undefined),
+				findExistingPrTab: vi.fn().mockResolvedValue(null),
+				activateTab: vi.fn().mockResolvedValue(undefined),
+				openNewTab: vi.fn().mockResolvedValue(undefined),
+				getCurrentTabUrl: vi.fn().mockResolvedValue(null),
+			};
+			services = {
+				auth: mockAuth,
+				tabNavigation: mockTabNavigation,
+			} as unknown as AppServices;
+			handler = createMessageHandler(services);
+		});
+
+		it("should activate existing tab when a matching PR tab is found", async () => {
+			mockTabNavigation.findExistingPrTab.mockResolvedValue(42);
+			const sendResponse = vi.fn();
+
+			handler(
+				{ type: "NAVIGATE_TO_PR", payload: { url: "https://github.com/owner/repo/pull/10" } },
+				createTrustedSender(),
+				sendResponse,
+			);
+
+			await vi.waitFor(() => {
+				expect(sendResponse).toHaveBeenCalled();
+			});
+
+			expect(mockTabNavigation.findExistingPrTab).toHaveBeenCalledWith(
+				"https://github.com/owner/repo/pull/10",
+			);
+			expect(mockTabNavigation.activateTab).toHaveBeenCalledWith(42);
+			expect(mockTabNavigation.openNewTab).not.toHaveBeenCalled();
+			const response = sendResponse.mock.calls[0][0];
+			expect(response).toEqual({ ok: true, data: undefined });
+		});
+
+		it("should open new tab when no matching PR tab exists", async () => {
+			mockTabNavigation.findExistingPrTab.mockResolvedValue(null);
+			const sendResponse = vi.fn();
+
+			handler(
+				{ type: "NAVIGATE_TO_PR", payload: { url: "https://github.com/owner/repo/pull/10" } },
+				createTrustedSender(),
+				sendResponse,
+			);
+
+			await vi.waitFor(() => {
+				expect(sendResponse).toHaveBeenCalled();
+			});
+
+			expect(mockTabNavigation.findExistingPrTab).toHaveBeenCalledWith(
+				"https://github.com/owner/repo/pull/10",
+			);
+			expect(mockTabNavigation.openNewTab).toHaveBeenCalledWith(
+				"https://github.com/owner/repo/pull/10",
+			);
+			expect(mockTabNavigation.activateTab).not.toHaveBeenCalled();
+			const response = sendResponse.mock.calls[0][0];
+			expect(response).toEqual({ ok: true, data: undefined });
+		});
+
+		it("should fallback to openNewTab when activateTab fails (TOCTOU)", async () => {
+			mockTabNavigation.findExistingPrTab.mockResolvedValue(42);
+			mockTabNavigation.activateTab.mockRejectedValue(new Error("Tab not found"));
+			const sendResponse = vi.fn();
+			handler(
+				{ type: "NAVIGATE_TO_PR", payload: { url: "https://github.com/owner/repo/pull/10" } },
+				createTrustedSender(),
+				sendResponse,
+			);
+			await vi.waitFor(() => {
+				expect(sendResponse).toHaveBeenCalled();
+			});
+			expect(mockTabNavigation.activateTab).toHaveBeenCalledWith(42);
+			expect(mockTabNavigation.openNewTab).toHaveBeenCalledWith(
+				"https://github.com/owner/repo/pull/10",
+			);
+			const response = sendResponse.mock.calls[0][0];
+			expect(response).toEqual({ ok: true, data: undefined });
+		});
+
+		it("should open new tab directly when URL is not a PR URL", async () => {
+			const sendResponse = vi.fn();
+
+			handler(
+				{ type: "NAVIGATE_TO_PR", payload: { url: "https://github.com/owner/repo/issues/5" } },
+				createTrustedSender(),
+				sendResponse,
+			);
+
+			await vi.waitFor(() => {
+				expect(sendResponse).toHaveBeenCalled();
+			});
+
+			expect(mockTabNavigation.findExistingPrTab).not.toHaveBeenCalled();
+			expect(mockTabNavigation.openNewTab).toHaveBeenCalledWith(
+				"https://github.com/owner/repo/issues/5",
+			);
 		});
 	});
 });

--- a/src/test/mocks/chrome.mock.ts
+++ b/src/test/mocks/chrome.mock.ts
@@ -44,10 +44,14 @@ type ChromeMock = {
 	tabs: {
 		query: ReturnType<typeof vi.fn>;
 		update: ReturnType<typeof vi.fn>;
+		create: ReturnType<typeof vi.fn>;
 		onUpdated: {
 			addListener: ReturnType<typeof vi.fn>;
 			removeListener: ReturnType<typeof vi.fn>;
 		};
+	};
+	windows: {
+		update: ReturnType<typeof vi.fn>;
 	};
 };
 
@@ -98,10 +102,14 @@ function createChromeMock(): ChromeMock {
 		tabs: {
 			query: vi.fn(),
 			update: vi.fn(),
+			create: vi.fn(),
 			onUpdated: {
 				addListener: vi.fn(),
 				removeListener: vi.fn(),
 			},
+		},
+		windows: {
+			update: vi.fn(),
 		},
 	};
 }


### PR DESCRIPTION
## 概要\nPR クリック時に既に同じ PR が開かれているタブがあれば新しいタブを開かずにそのタブをアクティブにする機能を実装。URL 完全一致ではなく `/files`, `/commits` 等のサブパスもプレフィックスマッチでヒットする。URL バリデーションと TOCTOU フォールバック（タブが閉じられた直後のレースコンディション対策）も実装。\n\n## 変更内容\n- `manifest.config.ts`: `permissions` に `\"tabs\"` を追加（`chrome.tabs.query` で URL パターンマッチに必要）\n- `src/domain/ports/tab-navigation.port.ts`: `findExistingPrTab`, `activateTab`, `openNewTab` メソッドをポートに追加\n- `src/adapter/chrome/tab-navigation.adapter.ts`: 上記3メソッドの Chrome API 実装（`chrome.tabs.query` → `extractPrBaseUrl` でプレフィックスマッチ）\n- `src/background/message-handler.ts`: `NAVIGATE_TO_PR` ハンドラに URL バリデーション、既存タブ再利用ロジック、TOCTOU フォールバック追加\n- `src/test/adapter/chrome/tab-navigation.adapter.test.ts`: adapter テスト 10 件追加\n- `src/test/background/message-handler.test.ts`: message-handler テスト 5 件追加\n- `src/test/background/message-handler-pr.test.ts`: mock 型の整合性修正\n- `src/test/mocks/chrome.mock.ts`: `tabs.create`, `windows.update` mock 追加\n\n## 関連 Issue\n- closes #198\n\n## テスト\n- [x] TypeScript 型チェック通過 (`pnpm check`)\n- [x] フロントエンドテスト通過 (`pnpm test`) — 567 テスト全 PASS\n- [x] Rust lint 通過 (`cargo clippy --all-targets`)\n- [x] Rust テスト通過 (`cargo test`)\n- [x] `/verify` で検証ループ PASS\n\n## レビュー観点\n- `findExistingPrTab` の `extractPrBaseUrl` によるプレフィックスマッチが PR 番号の部分一致 (`pull/4` vs `pull/42`) を正しく排除しているか\n- `activateTab` の TOCTOU フォールバック（try/catch → openNewTab）が適切か\n- URL バリデーション (`https://github.com/` プレフィックスチェック) が十分か\n- `tabs` パーミッション追加の妥当性