### PR TITLE
fix: PrSection に onNavigate prop を追加し PrItem に中継する

### DIFF
--- a/src/sidepanel/App.svelte
+++ b/src/sidepanel/App.svelte
@@ -11,8 +11,9 @@
 		prUseCase: ReturnType<typeof createPrUseCase>;
 		deviceFlowController: DeviceFlowController;
 		subscribeToMessages: (callback: (message: unknown) => void) => () => void;
+		onNavigate?: (url: string) => void;
 	};
-	const { authUseCase, prUseCase, deviceFlowController, subscribeToMessages }: Props = $props();
+	const { authUseCase, prUseCase, deviceFlowController, subscribeToMessages, onNavigate }: Props = $props();
 
 	let authenticated = $state(false);
 	let loading = $state(true);
@@ -52,7 +53,7 @@
 		<p>Loading...</p>
 	</div>
 {:else if authenticated}
-	<MainScreen onLogout={handleLogout} fetchPrs={() => prUseCase.fetchPrs()} getCachedPrs={() => prUseCase.getCachedPrs()} loadPrsWithCache={(minutes: number) => prUseCase.loadPrsWithCache(minutes)} {subscribeToMessages} />
+	<MainScreen onLogout={handleLogout} fetchPrs={() => prUseCase.fetchPrs()} getCachedPrs={() => prUseCase.getCachedPrs()} loadPrsWithCache={(minutes: number) => prUseCase.loadPrsWithCache(minutes)} {subscribeToMessages} {onNavigate} />
 {:else}
 	<LoginScreen controller={deviceFlowController} />
 {/if}

--- a/src/sidepanel/components/MainScreen.svelte
+++ b/src/sidepanel/components/MainScreen.svelte
@@ -13,9 +13,10 @@
 		getCachedPrs: () => Promise<CachedPrData | null>;
 		loadPrsWithCache: (minutes: number) => Promise<(ProcessedPrsResult & { hasMore: boolean }) | null>;
 		subscribeToMessages: (callback: (message: unknown) => void) => () => void;
+		onNavigate?: (url: string) => void;
 	};
 
-	const { onLogout, fetchPrs, getCachedPrs, loadPrsWithCache, subscribeToMessages }: Props = $props();
+	const { onLogout, fetchPrs, getCachedPrs, loadPrsWithCache, subscribeToMessages, onNavigate }: Props = $props();
 
 	let loading = $state(true);
 	let error = $state<string | null>(null);
@@ -147,8 +148,8 @@
 				<p class="error-text">{error}</p>
 			</div>
 		{/if}
-		<PrSection title="My PRs" items={data.myPrs.items} />
-		<PrSection title="Review Requests" items={data.reviewRequests.items} />
+		<PrSection title="My PRs" items={data.myPrs.items} {onNavigate} />
+		<PrSection title="Review Requests" items={data.reviewRequests.items} {onNavigate} />
 	{/if}
 </main>
 

--- a/src/sidepanel/components/PrSection.svelte
+++ b/src/sidepanel/components/PrSection.svelte
@@ -6,9 +6,10 @@
 		title: string;
 		items: readonly PrItemDto[];
 		isOpen?: boolean;
+		onNavigate?: (url: string) => void;
 	};
 
-	const { title, items, isOpen: initialOpen = true }: Props = $props();
+	const { title, items, isOpen: initialOpen = true, onNavigate }: Props = $props();
 
 	let open = $state(initialOpen);
 
@@ -30,7 +31,7 @@
 				<p class="empty-message">PR がありません</p>
 			{:else}
 				{#each items as pr (pr.url)}
-					<PrItem {pr} />
+					<PrItem {pr} {onNavigate} />
 				{/each}
 			{/if}
 		</div>

--- a/src/sidepanel/main.ts
+++ b/src/sidepanel/main.ts
@@ -5,6 +5,7 @@ import { ChromeStorageAdapter } from "../adapter/chrome/storage.adapter";
 import { createAuthUseCase } from "../shared/usecase/auth.usecase";
 import { createDeviceFlowController } from "../shared/usecase/device-flow.controller";
 import { createPrUseCase } from "../shared/usecase/pr.usecase";
+import { createTabNavigationUseCase } from "../shared/usecase/tab-navigation.usecase";
 import App from "./App.svelte";
 
 const target = document.getElementById("app");
@@ -16,10 +17,17 @@ const authUseCase = createAuthUseCase(chromeSendMessage);
 const deviceFlowController = createDeviceFlowController(authUseCase);
 const storage = new ChromeStorageAdapter();
 const prUseCase = createPrUseCase(chromeSendMessage, storage);
+const tabNavigationUseCase = createTabNavigationUseCase(chromeSendMessage);
 
 const app = mount(App, {
 	target,
-	props: { authUseCase, prUseCase, deviceFlowController, subscribeToMessages },
+	props: {
+		authUseCase,
+		prUseCase,
+		deviceFlowController,
+		subscribeToMessages,
+		onNavigate: (url: string) => tabNavigationUseCase.navigateToPr(url),
+	},
 });
 
 export default app;

--- a/src/test/sidepanel/components/MainScreen.test.ts
+++ b/src/test/sidepanel/components/MainScreen.test.ts
@@ -32,6 +32,7 @@ function createDefaultProps() {
 		getCachedPrs: createMockGetCachedPrs(),
 		loadPrsWithCache: createMockLoadPrsWithCache(),
 		subscribeToMessages: createMockSubscribeToMessages(),
+		onNavigate: vi.fn(),
 	};
 }
 
@@ -156,6 +157,59 @@ describe("MainScreen", () => {
 		});
 
 		vi.useRealTimers();
+	});
+
+	it("should call onNavigate when a PR item is clicked in the loaded state", async () => {
+		const onNavigate = vi.fn();
+		const mockGetCachedPrs = vi.fn(async () => ({
+			data: {
+				myPrs: {
+					items: [
+						{
+							id: "PR_100",
+							number: 100,
+							title: "Test PR for navigation",
+							author: "testuser",
+							url: "https://github.com/owner/repo/pull/100",
+							repository: "owner/repo",
+							isDraft: false,
+							approvalStatus: "ReviewRequired" as const,
+							ciStatus: "Passed" as const,
+							mergeableStatus: "Unknown" as const,
+							additions: 5,
+							deletions: 2,
+							createdAt: "2026-03-20T10:00:00Z",
+							updatedAt: "2026-03-23T10:00:00Z",
+							sizeLabel: "S",
+							unresolvedCommentCount: 0,
+						},
+					],
+					totalCount: 1,
+				},
+				reviewRequests: { items: [], totalCount: 0 },
+				hasMore: false,
+			},
+			lastUpdatedAt: "2026-03-23T10:00:00.000Z",
+		}));
+
+		component = mount(MainScreen, {
+			target: document.body,
+			props: {
+				...createDefaultProps(),
+				getCachedPrs: mockGetCachedPrs,
+				onNavigate,
+			},
+		});
+
+		// キャッシュからデータが読み込まれるのを待つ
+		await vi.waitFor(() => {
+			expect(document.querySelector(".pr-item")).not.toBeNull();
+		});
+
+		const prItem = document.querySelector(".pr-item") as HTMLElement;
+		prItem.click();
+
+		expect(onNavigate).toHaveBeenCalledWith("https://github.com/owner/repo/pull/100");
 	});
 
 	it("should call unsubscribe when unmounted", async () => {

--- a/src/test/sidepanel/components/PrSection.test.ts
+++ b/src/test/sidepanel/components/PrSection.test.ts
@@ -1,0 +1,146 @@
+import { mount, unmount } from "svelte";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { PrItemDto } from "../../../domain/ports/pr-processor.port";
+import PrSection from "../../../sidepanel/components/PrSection.svelte";
+
+function createPrItemDto(overrides: Partial<PrItemDto> = {}): PrItemDto {
+	return {
+		id: "PR_123",
+		number: 42,
+		title: "Add feature X",
+		author: "octocat",
+		url: "https://github.com/owner/repo/pull/42",
+		repository: "owner/repo",
+		isDraft: false,
+		approvalStatus: "ReviewRequired",
+		ciStatus: "Passed",
+		mergeableStatus: "Unknown",
+		additions: 10,
+		deletions: 3,
+		createdAt: "2026-03-20T10:00:00Z",
+		updatedAt: "2026-03-23T10:00:00Z",
+		sizeLabel: "S",
+		unresolvedCommentCount: 0,
+		...overrides,
+	};
+}
+
+describe("PrSection", () => {
+	let component: ReturnType<typeof mount>;
+
+	afterEach(() => {
+		if (component) {
+			unmount(component);
+		}
+		document.body.innerHTML = "";
+	});
+
+	it("should call onNavigate with the PR url when a PR item is clicked", () => {
+		const onNavigate = vi.fn();
+		const pr = createPrItemDto();
+		component = mount(PrSection, {
+			target: document.body,
+			props: {
+				title: "My PRs",
+				items: [pr],
+				onNavigate,
+			},
+		});
+
+		const prItem = document.querySelector(".pr-item") as HTMLElement;
+		expect(prItem).not.toBeNull();
+		prItem.click();
+		expect(onNavigate).toHaveBeenCalledWith("https://github.com/owner/repo/pull/42");
+	});
+
+	it("should not throw when clicked without onNavigate prop", () => {
+		const pr = createPrItemDto();
+		component = mount(PrSection, {
+			target: document.body,
+			props: {
+				title: "My PRs",
+				items: [pr],
+			},
+		});
+
+		const prItem = document.querySelector(".pr-item") as HTMLElement;
+		expect(prItem).not.toBeNull();
+		// クリックしてもエラーにならないことを確認
+		expect(() => prItem.click()).not.toThrow();
+	});
+
+	it("should not render PR items when the section is closed", () => {
+		const pr = createPrItemDto();
+		component = mount(PrSection, {
+			target: document.body,
+			props: {
+				title: "My PRs",
+				items: [pr],
+				isOpen: false,
+			},
+		});
+
+		const prItem = document.querySelector(".pr-item");
+		expect(prItem).toBeNull();
+	});
+
+	it("should call onNavigate with the correct URL for each PR when multiple items are clicked", () => {
+		const onNavigate = vi.fn();
+		const pr1 = createPrItemDto({
+			id: "PR_1",
+			number: 1,
+			title: "First PR",
+			url: "https://github.com/owner/repo/pull/1",
+		});
+		const pr2 = createPrItemDto({
+			id: "PR_2",
+			number: 2,
+			title: "Second PR",
+			url: "https://github.com/owner/repo/pull/2",
+		});
+		const pr3 = createPrItemDto({
+			id: "PR_3",
+			number: 3,
+			title: "Third PR",
+			url: "https://github.com/owner/repo/pull/3",
+		});
+
+		component = mount(PrSection, {
+			target: document.body,
+			props: {
+				title: "My PRs",
+				items: [pr1, pr2, pr3],
+				onNavigate,
+			},
+		});
+
+		const prItems = document.querySelectorAll(".pr-item");
+		expect(prItems).toHaveLength(3);
+
+		// 各 PR をクリックして、対応する URL で onNavigate が呼ばれることを検証
+		(prItems[0] as HTMLElement).click();
+		expect(onNavigate).toHaveBeenCalledWith("https://github.com/owner/repo/pull/1");
+
+		(prItems[1] as HTMLElement).click();
+		expect(onNavigate).toHaveBeenCalledWith("https://github.com/owner/repo/pull/2");
+
+		(prItems[2] as HTMLElement).click();
+		expect(onNavigate).toHaveBeenCalledWith("https://github.com/owner/repo/pull/3");
+
+		expect(onNavigate).toHaveBeenCalledTimes(3);
+	});
+
+	it("should display empty message when items array is empty", () => {
+		component = mount(PrSection, {
+			target: document.body,
+			props: {
+				title: "My PRs",
+				items: [],
+			},
+		});
+
+		const emptyMessage = document.querySelector(".empty-message");
+		expect(emptyMessage).not.toBeNull();
+		expect(emptyMessage?.textContent?.trim()).toBe("PR がありません");
+	});
+});


### PR DESCRIPTION
## 概要

`PrSection.svelte` が `PrItem` に `onNavigate` コールバックを渡しておらず、PR クリック時に `NAVIGATE_TO_PR` メッセージが発火せずタブ遷移機能が動作しなかった問題を修正。`main.ts` で `tabNavigationUseCase.navigateToPr` を生成し、`App` → `MainScreen` → `PrSection` → `PrItem` のバケツリレーで注入する。

## 変更内容

- `src/sidepanel/components/PrSection.svelte`: `onNavigate` prop を追加し、`PrItem` に中継
- `src/sidepanel/components/MainScreen.svelte`: `onNavigate` prop を追加し、両方の `PrSection` に中継
- `src/sidepanel/App.svelte`: `onNavigate` prop を追加し、`MainScreen` に中継
- `src/sidepanel/main.ts`: `createTabNavigationUseCase` を生成し、`navigateToPr` を `onNavigate` としてバインド
- `src/test/sidepanel/components/PrSection.test.ts`: 新規作成。onNavigate 伝搬、省略時の安全性、セクション閉じ、空配列、複数 PR の 5 テスト
- `src/test/sidepanel/components/MainScreen.test.ts`: `createDefaultProps` に `onNavigate` 追加、クリック→onNavigate 呼び出しの統合テスト追加

## 関連 Issue

- closes #207

## テスト

- [x] TypeScript 型チェック通過 (`pnpm check`)
- [x] フロントエンドテスト通過 (`pnpm test`) — 583 tests passed
- [ ] Rust lint 通過 (`cargo clippy --all-targets`) — Rust 変更なし
- [ ] Rust テスト通過 (`cargo test`) — Rust 変更なし
- [x] `/verify` で検証ループ PASS

## レビュー観点

- `onNavigate` のバケツリレーが既存の `onLogout` パターンと整合しているか
- `main.ts` での `tabNavigationUseCase` 注入タイミングが適切か
- テストが要件を十分にカバーしているか