### PR TITLE
refactor: 変更行数の表示をバッジからプレーンテキストに変更

### DIFF
--- a/src/sidepanel/components/SizeBadge.svelte
+++ b/src/sidepanel/components/SizeBadge.svelte
@@ -1,6 +1,4 @@
 <script lang="ts">
-	import "../styles/badge.css";
-
 	type Props = Readonly<{
 		additions: number;
 		deletions: number;
@@ -9,5 +7,24 @@
 	const { additions, deletions }: Props = $props();
 </script>
 
-<span class="badge badge-green">+{additions}</span>
-<span class="badge badge-red">-{deletions}</span>
+<span class="size-text">
+	<span class="size-additions">+{additions}</span>
+	<span class="size-deletions">-{deletions}</span>
+</span>
+
+<style>
+	.size-text {
+		font-size: 11px;
+		font-family: var(--font-mono, monospace);
+		letter-spacing: -0.02em;
+	}
+
+	.size-additions {
+		color: var(--color-success, #3fb950);
+	}
+
+	.size-deletions {
+		color: var(--color-danger, #f85149);
+		margin-left: 4px;
+	}
+</style>

--- a/src/test/sidepanel/components/SizeBadge.test.ts
+++ b/src/test/sidepanel/components/SizeBadge.test.ts
@@ -12,37 +12,37 @@ describe("SizeBadge", () => {
 		document.body.innerHTML = "";
 	});
 
-	it("should render additions in .badge-green and deletions in .badge-red", () => {
+	it("should render additions and deletions as text", () => {
 		component = mount(SizeBadge, {
 			target: document.body,
 			props: { additions: 3, deletions: 2 },
 		});
-		const green = document.querySelector(".badge-green");
-		const red = document.querySelector(".badge-red");
-		expect(green).not.toBeNull();
-		expect(green?.textContent?.trim()).toBe("+3");
-		expect(red).not.toBeNull();
-		expect(red?.textContent?.trim()).toBe("-2");
+		const additions = document.querySelector(".size-additions");
+		const deletions = document.querySelector(".size-deletions");
+		expect(additions).not.toBeNull();
+		expect(additions?.textContent?.trim()).toBe("+3");
+		expect(deletions).not.toBeNull();
+		expect(deletions?.textContent?.trim()).toBe("-2");
 	});
 
-	it("should render +0 in .badge-green when additions is 0", () => {
+	it("should render +0 when additions is 0", () => {
 		component = mount(SizeBadge, {
 			target: document.body,
 			props: { additions: 0, deletions: 5 },
 		});
-		const green = document.querySelector(".badge-green");
-		expect(green).not.toBeNull();
-		expect(green?.textContent?.trim()).toBe("+0");
+		const additions = document.querySelector(".size-additions");
+		expect(additions).not.toBeNull();
+		expect(additions?.textContent?.trim()).toBe("+0");
 	});
 
-	it("should render -0 in .badge-red when deletions is 0", () => {
+	it("should render -0 when deletions is 0", () => {
 		component = mount(SizeBadge, {
 			target: document.body,
 			props: { additions: 8, deletions: 0 },
 		});
-		const red = document.querySelector(".badge-red");
-		expect(red).not.toBeNull();
-		expect(red?.textContent?.trim()).toBe("-0");
+		const deletions = document.querySelector(".size-deletions");
+		expect(deletions).not.toBeNull();
+		expect(deletions?.textContent?.trim()).toBe("-0");
 	});
 
 	it("should render large values correctly", () => {
@@ -50,34 +50,22 @@ describe("SizeBadge", () => {
 			target: document.body,
 			props: { additions: 800, deletions: 200 },
 		});
-		const green = document.querySelector(".badge-green");
-		const red = document.querySelector(".badge-red");
-		expect(green).not.toBeNull();
-		expect(green?.textContent?.trim()).toBe("+800");
-		expect(red).not.toBeNull();
-		expect(red?.textContent?.trim()).toBe("-200");
+		const additions = document.querySelector(".size-additions");
+		const deletions = document.querySelector(".size-deletions");
+		expect(additions).not.toBeNull();
+		expect(additions?.textContent?.trim()).toBe("+800");
+		expect(deletions).not.toBeNull();
+		expect(deletions?.textContent?.trim()).toBe("-200");
 	});
 
-	it("should render .badge-green and .badge-red with zero values", () => {
+	it("should render with zero values", () => {
 		component = mount(SizeBadge, {
 			target: document.body,
 			props: { additions: 0, deletions: 0 },
 		});
-		const green = document.querySelector(".badge-green");
-		const red = document.querySelector(".badge-red");
-		expect(green).not.toBeNull();
-		expect(red).not.toBeNull();
-	});
-
-	it("should not have any size-xs through size-xl classes in the DOM", () => {
-		component = mount(SizeBadge, {
-			target: document.body,
-			props: { additions: 10, deletions: 5 },
-		});
-		expect(document.querySelector(".size-xs")).toBeNull();
-		expect(document.querySelector(".size-s")).toBeNull();
-		expect(document.querySelector(".size-m")).toBeNull();
-		expect(document.querySelector(".size-l")).toBeNull();
-		expect(document.querySelector(".size-xl")).toBeNull();
+		const additions = document.querySelector(".size-additions");
+		const deletions = document.querySelector(".size-deletions");
+		expect(additions).not.toBeNull();
+		expect(deletions).not.toBeNull();
 	});
 });


### PR DESCRIPTION
## 概要
変更行数（additions/deletions）の表示をバッジスタイルからプレーンテキストスタイルに変更。

## 変更内容
- `src/sidepanel/components/SizeBadge.svelte`: バッジ（`badge badge-green/red`）をやめてモノスペースのテキスト表示（`+123 -45`）に変更
- `badge.css` の import を削除し、scoped style で色付け

## 関連 Issue
なし（UI 改善）

## テスト
- [x] `pnpm build` 成功
- [x] 変更行数がテキストで表示されることを確認

## レビュー観点
- テキスト表示の見た目・視認性が問題ないか

🤖 Generated with [Claude Code](https://claude.com/claude-code)